### PR TITLE
GithubActions: Run Ubuntu action on 20.04

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -5,36 +5,14 @@ on:
     tags:
     - '*'
 
-jobs:
-  ubuntu-snap-build:
-    runs-on: ubuntu-18.04
+jobs: 
+  ubuntu-snap-build-and-upload:
+    runs-on: ubuntu-latest
+    name: Build and upload snap
     steps:
-    - uses: actions/checkout@v1
-    - name: Generate snap package
-      run: |
-        sudo apt update
-        ./scripts/install_snapcraft.sh
-        sudo ./scripts/snap_build.sh
-
-    - name: Upload snap package as artifact
-      uses: actions/upload-artifact@v1
-      with:
-        name: snap
-        path: gwallet_0.3.207.0_amd64.snap
-
-  ubuntu-snap-upload:
-    needs: ubuntu-snap-build
-    runs-on: ubuntu-18.04
-    steps:
-    - uses: actions/checkout@v1
-    - name: Download artifact from previous job
-      uses: actions/download-artifact@v1
-      with:
-        name: snap
-    - name: Upload snap package to Snap Store
-      env:
-        SNAPCRAFT_LOGIN: ${{ secrets.SNAPCRAFT_LOGIN }}
-      run: |
-        sudo apt update
-        ./scripts/install_snapcraft.sh
-        ./scripts/snap_release.sh
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Run build and upload snap
+        uses: ./docker/ubuntu-snap-20.04
+        env:
+          SNAPCRAFT_LOGIN: ${{ secrets.SNAPCRAFT_LOGIN }}

--- a/docker/ubuntu-snap-20.04/Dockerfile
+++ b/docker/ubuntu-snap-20.04/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:20.04
+COPY entrypoint-ubuntu-snap.sh /entrypoint-ubuntu-snap.sh
+ENTRYPOINT ["/entrypoint-ubuntu-snap.sh"]

--- a/docker/ubuntu-snap-20.04/action.yml
+++ b/docker/ubuntu-snap-20.04/action.yml
@@ -1,0 +1,5 @@
+name: 'Build and upload snap'
+description: 'Build and upload snap'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/docker/ubuntu-snap-20.04/entrypoint-ubuntu-snap.sh
+++ b/docker/ubuntu-snap-20.04/entrypoint-ubuntu-snap.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Update system
+apt update -y && apt upgrade -y
+
+# Install dependencies
+DEBIAN_FRONTEND=noninteractive apt install lsb-release git docker.io -y
+
+# Install snap and snapcraft
+./docker/ubuntu-snap-20.04/scripts/install_snap.sh
+
+# Build repo from source inside snappy container
+docker exec snappy ./configure.sh --prefix=./staging
+docker exec snappy make
+docker exec snappy make install
+
+# Install snapcraft and dependencies
+docker exec snappy snap version
+docker exec snappy snap install core20
+docker exec snappy snap install --classic --stable snapcraft
+docker exec snappy snapcraft --version
+
+# Build snap package
+docker exec snappy snapcraft --destructive-mode
+
+# Upload snap package
+cat <<EOF | docker exec --interactive -e SNAPCRAFT_LOGIN=$SNAPCRAFT_LOGIN snappy sh
+if [ ! -e *.snap ]; then
+    echo "No snap package found."
+    exit 1
+fi
+
+if [ -e snapcraft.login ]; then
+    echo "snapcraft.login found, skipping log-in"
+else
+    if [ ! -z "$SNAPCRAFT_LOGIN" ]; then
+        echo "$SNAPCRAFT_LOGIN" > snapcraft.login
+    else
+        echo "No login details found, initiating manual logging-in..."
+        snapcraft export-login snapcraft.login
+    fi
+fi
+snapcraft login --with snapcraft.login
+snapcraft push *.snap --release=beta
+EOF

--- a/docker/ubuntu-snap-20.04/scripts/install_snap.sh
+++ b/docker/ubuntu-snap-20.04/scripts/install_snap.sh
@@ -1,0 +1,135 @@
+set -e
+
+CONTNAME=snappy
+IMGNAME=snapd
+RELEASE=20.04
+
+SUDO=""
+if [ -z "$(id -Gn|grep docker)" ] && [ "$(id -u)" != "0" ]; then
+    SUDO="sudo"
+fi
+
+if [ "$(which docker)" = "/snap/bin/docker" ]; then
+    export TMPDIR="$(readlink -f ~/snap/docker/current)"
+	# we need to run the snap once to have $SNAP_USER_DATA created
+	/snap/bin/docker >/dev/null 2>&1
+fi
+
+BUILDDIR=$(mktemp -d)
+# Copy repo contents to build dir
+$SUDO cp -r /github/workspace $BUILDDIR/geewallet
+
+usage() {
+    echo "usage: $(basename $0) [options]"
+    echo
+    echo "  -c|--containername <name> (default: snappy)"
+    echo "  -i|--imagename <name> (default: snapd)"
+    rm_builddir
+}
+
+print_info() {
+    echo
+    echo "use: $SUDO docker exec -it $CONTNAME <command> ... to run a command inside this container"
+    echo
+    echo "to remove the container use: $SUDO docker rm -f $CONTNAME"
+    echo "to remove the related image use: $SUDO docker rmi $IMGNAME"
+}
+
+clean_up() {
+    sleep 1
+    $SUDO docker rm -f $CONTNAME >/dev/null 2>&1 || true
+    $SUDO docker rmi $IMGNAME >/dev/null 2>&1 || true
+    $SUDO docker rmi $($SUDO docker images -f "dangling=true" -q) >/dev/null 2>&1 || true
+    rm_builddir
+}
+
+rm_builddir() {
+    rm -rf $BUILDDIR || true
+    exit 0
+}
+
+trap clean_up 1 2 3 4 9 15
+
+while [ $# -gt 0 ]; do
+       case "$1" in
+               -c|--containername)
+                       [ -n "$2" ] && CONTNAME=$2 shift || usage
+                       ;;
+               -i|--imagename)
+                       [ -n "$2" ] && IMGNAME=$2 shift || usage
+                       ;;
+               -h|--help)
+                       usage
+                       ;;
+               *)
+                       usage
+                       ;;
+       esac
+       shift
+done
+
+if [ -n "$($SUDO docker ps -f name=$CONTNAME -q)" ]; then
+    echo "Container $CONTNAME already running!"
+    print_info
+    rm_builddir
+fi
+
+if [ -z "$($SUDO docker images|grep $IMGNAME)" ]; then
+    cat << EOF > $BUILDDIR/Dockerfile
+FROM ubuntu:$RELEASE
+ENV container docker
+ENV PATH "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+RUN apt-get update &&\
+ DEBIAN_FRONTEND=noninteractive\
+ apt-get install -y fuse snapd snap-confine squashfuse sudo init lsb-release git docker.io fsharp build-essential pkg-config cli-common-dev mono-devel &&\
+ apt-get clean &&\
+ dpkg-divert --local --rename --add /sbin/udevadm &&\
+ ln -s /bin/true /sbin/udevadm
+RUN systemctl enable snapd
+VOLUME ["/sys/fs/cgroup"]
+STOPSIGNAL SIGRTMIN+3
+RUN mkdir -p /geewallet
+WORKDIR /geewallet
+ADD geewallet /geewallet
+CMD ["/sbin/init"]
+EOF
+    $SUDO docker build -t $IMGNAME --force-rm=true --rm=true $BUILDDIR || clean_up
+fi
+
+# start the detached container
+$SUDO docker run \
+    --name=$CONTNAME \
+    -ti \
+    --tmpfs /run \
+    --tmpfs /run/lock \
+    --tmpfs /tmp \
+    --cap-add SYS_ADMIN \
+    --device=/dev/fuse \
+    --security-opt apparmor:unconfined \
+    --security-opt seccomp:unconfined \
+    -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+    -v /lib/modules:/lib/modules:ro \
+    -d $IMGNAME || clean_up
+
+# wait for snapd to start
+TIMEOUT=100
+SLEEP=0.1
+echo -n "Waiting up to $(($TIMEOUT/10)) seconds for snapd startup "
+while [ "$($SUDO docker exec $CONTNAME sh -c 'systemctl status snapd.seeded >/dev/null 2>&1; echo $?')" != "0" ]; do
+    echo -n "."
+    sleep $SLEEP || clean_up
+    if [ "$TIMEOUT" -le "0" ]; then
+        echo " Timed out!"
+        clean_up
+    fi
+    TIMEOUT=$(($TIMEOUT-1))
+done
+echo " done"
+
+$SUDO docker exec $CONTNAME snap install core --edge || clean_up
+echo "container $CONTNAME started ..."
+
+print_info
+rm_builddir

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: gwallet
-base: core18 # the base snap is the execution environment for this snap
+base: core20 # the base snap is the execution environment for this snap
 version: '0.3.207.0' # just for humans, typically '1.2+git' or '1.3.2'
 summary: minimalistic cryptocurrency brainwallet # 79 char long summary
 description: |


### PR DESCRIPTION
### Github Actions: Run Ubuntu action on 20.04

Github actions does currently not support Ubuntu 20.04 natively.
This PR updates the Ubuntu pipeline to use a 20.04 docker image.
Inside the 20.04 docker image another docker container is used to
run snap and snapcraft as they need special customization to run in a
docker container which cannot be achieved via the Github Actions yaml.