### PR TITLE
DRAFT: Option to print BTC transactions

### DIFF
--- a/src/GWallet.Backend/GWallet.Backend.fsproj
+++ b/src/GWallet.Backend/GWallet.Backend.fsproj
@@ -73,6 +73,7 @@
     <Compile Include="UtxoCoin\UtxoCoinMinerFee.fs" />
     <Compile Include="UtxoCoin\TransactionTypes.fs" />
     <Compile Include="UtxoCoin\UtxoCoinAccount.fs" />
+    <Compile Include="UtxoCoin\BtcTransactionPrinting.fs" />
     <Compile Include="Ether\EtherExceptions.fs" />
     <Compile Include="Ether\EtherMinerFee.fs" />
     <Compile Include="Ether\TransactionMetadata.fs" />

--- a/src/GWallet.Backend/Server.fs
+++ b/src/GWallet.Backend/Server.fs
@@ -124,6 +124,11 @@ module ServerRegistry =
             // they create exception when being queried for advanced ones (e.g. latest block)
             server.ServerInfo.NetworkPath.Contains "blockscout" ||
 
+            // Blockstream electrum servers doesn't support sending verbose transactions, we use this functionality
+            // for getting confirmations of a transaction, this causes geewallet to crash. See:
+            // https://github.com/Blockstream/electrs/pull/36
+            server.ServerInfo.NetworkPath.Contains "blockstream" ||
+
             // there was a mistake when adding this server to geewallet's JSON: it was added in the ETC currency instead of ETH
             (currency = Currency.ETC && server.ServerInfo.NetworkPath.Contains "ethrpc.mewapi.io")
 

--- a/src/GWallet.Backend/UtxoCoin/BtcTransactionPrinting.fs
+++ b/src/GWallet.Backend/UtxoCoin/BtcTransactionPrinting.fs
@@ -1,0 +1,84 @@
+﻿namespace GWallet.Backend.UtxoCoin
+
+open System
+open System.Net
+
+open GWallet.Backend
+open GWallet.Backend.FSharpUtil
+open GWallet.Backend.FSharpUtil.UwpHacks
+
+
+module BtcTransactionPrinting =
+    let GetBitcoinPriceForDate (date: DateTime) : Async<Result<decimal, Exception>> =
+        async {
+            try
+                let baseUrl = 
+                    let dateFormated = date.ToString("dd-MM-yyyy")
+                    SPrintF1 "https://api.coingecko.com/api/v3/coins/bitcoin/history?date=%s&localization=false" dateFormated
+                let uri = Uri baseUrl
+                use webClient = new WebClient()
+                let task = webClient.DownloadStringTaskAsync uri
+                let! result = Async.AwaitTask task
+                let json = Newtonsoft.Json.Linq.JObject.Parse result
+                return Ok(json.["market_data"].["current_price"].["usd"].ToObject<decimal>())
+            with
+            | ex ->
+                return Error ex
+        }
+
+    let PrintTransactions (maxTransactionsCount: uint32) (btcAddress: string) =
+        let address = NBitcoin.BitcoinAddress.Create(btcAddress, NBitcoin.Network.Main)
+        async { 
+            let scriptHash = Account.GetElectrumScriptHashFromPublicAddress Currency.BTC btcAddress
+            let! history =
+                Server.Query
+                    Currency.BTC
+                    (QuerySettings.Default ServerSelectionMode.Fast)
+                    (ElectrumClient.GetBlockchainScriptHashHistory scriptHash)
+                    None
+
+            let sortedHistory = history |> List.sortByDescending (fun entry -> entry.Height)
+            
+            let rec processHistory history (maxTransactionsToPrint: uint32) =
+                match history with
+                | nextEntry :: rest when maxTransactionsToPrint > 0u ->
+                    async {
+                        let! transaction = 
+                            Server.Query
+                                Currency.BTC
+                                (QuerySettings.Default ServerSelectionMode.Fast)
+                                (ElectrumClient.GetBlockchainTransactionVerbose nextEntry.TxHash)
+                                None
+                        let transactionInfo = NBitcoin.Transaction.Parse(transaction.Hex, NBitcoin.Network.Main)
+
+                        let incomingOutputs =
+                            transactionInfo.Outputs 
+                            |> Seq.filter (fun output -> output.IsTo address)
+
+                        if not (Seq.isEmpty incomingOutputs) then
+                            let amount = incomingOutputs |> Seq.sumBy (fun txOut -> txOut.Value)
+                            let dateTime = 
+                                let startOfUnixEpoch = DateTime(1970, 1, 1)
+                                startOfUnixEpoch + TimeSpan.FromSeconds(float transaction.Time)
+                            let! bitcoinPrice = GetBitcoinPriceForDate dateTime
+                            Console.WriteLine(SPrintF1 "BTC amount: %A" amount)
+                            match bitcoinPrice with
+                            | Ok price -> 
+                                let bitcoinAmount = amount.ToDecimal(NBitcoin.MoneyUnit.BTC) 
+                                Console.WriteLine(SPrintF1 "~USD amount: %s" ((bitcoinAmount * price).ToString("F2")))
+                            | Error exn -> 
+                                Console.WriteLine("Could not get bitcoin price for the date. An error has occured:\n" + exn.ToString())
+                            Console.WriteLine(SPrintF1 "date: %A UTC" dateTime)
+                            Console.WriteLine()
+                            return! processHistory rest (maxTransactionsToPrint - 1u)
+                        else
+                            return! processHistory rest maxTransactionsToPrint
+                    }
+                | _ -> async { return () }
+            
+            do! processHistory sortedHistory maxTransactionsCount
+            Console.WriteLine("End of results")
+            Console.ReadKey() |> ignore
+            return 0
+        }
+        |> Async.RunSynchronously

--- a/src/GWallet.Backend/UtxoCoin/ElectrumClient.fs
+++ b/src/GWallet.Backend/UtxoCoin/ElectrumClient.fs
@@ -77,9 +77,21 @@ module ElectrumClient =
         return unspentListResult.Result
     }
 
+    let GetBlockchainScriptHashHistory scriptHash (stratumServer: Async<StratumClient>) = async {
+        let! stratumClient = stratumServer
+        let! history = stratumClient.BlockchainScriptHashHistory scriptHash
+        return history.Result
+    }
+
     let GetBlockchainTransaction txHash (stratumServer: Async<StratumClient>) = async {
         let! stratumClient = stratumServer
         let! blockchainTransactionResult = stratumClient.BlockchainTransactionGet txHash
+        return blockchainTransactionResult.Result
+    }
+
+    let GetBlockchainTransactionVerbose (txHash: string) (stratumServer: Async<StratumClient>) = async {
+        let! stratumClient = stratumServer
+        let! blockchainTransactionResult = stratumClient.BlockchainTransactionGetVerbose txHash
         return blockchainTransactionResult.Result
     }
 

--- a/src/GWallet.Backend/UtxoCoin/StratumClient.fs
+++ b/src/GWallet.Backend/UtxoCoin/StratumClient.fs
@@ -45,10 +45,36 @@ type BlockchainScriptHashListUnspentResult =
         Result: array<BlockchainScriptHashListUnspentInnerResult>
     }
 
+type BlockchainScriptHashHistoryInnerResult =
+    {
+        TxHash: string
+        Height: uint32
+    }
+
+type BlockchainScriptHashHistoryResult =
+    {
+        Id: int
+        Result: List<BlockchainScriptHashHistoryInnerResult>
+    }
+
 type BlockchainTransactionGetResult =
     {
         Id: int;
         Result: string;
+    }
+
+type BlockchainTransactionGetVerboseInnerResult =
+    {
+        Locktime: uint32
+        Confirmations: uint32
+        Hex: string
+        Time: uint32
+    }
+
+type BlockchainTransactionGetVerboseResult =
+    {
+        Id: int
+        Result: BlockchainTransactionGetVerboseInnerResult
     }
 
 type BlockchainEstimateFeeResult =
@@ -246,6 +272,18 @@ type StratumClient (jsonRpcClient: JsonRpcTcpClient) =
             return resObj
         }
 
+    member self.BlockchainScriptHashHistory scriptHash: Async<BlockchainScriptHashHistoryResult> =
+        let obj = {
+            Id = 0
+            Method = "blockchain.scripthash.get_history"
+            Params = scriptHash :: List.Empty
+        }
+        let json = Serialize obj
+        async {
+            let! resObj,_ = self.Request<BlockchainScriptHashHistoryResult> json
+            return resObj
+        }
+
     member self.BlockchainTransactionGet txHash: Async<BlockchainTransactionGetResult> =
         let obj = {
             Id = 0;
@@ -255,6 +293,18 @@ type StratumClient (jsonRpcClient: JsonRpcTcpClient) =
         let json = Serialize obj
         async {
             let! resObj,_ = self.Request<BlockchainTransactionGetResult> json
+            return resObj
+        }
+
+    member self.BlockchainTransactionGetVerbose (txHash: string): Async<BlockchainTransactionGetVerboseResult> =
+        let obj = {
+            Id = 0
+            Method = "blockchain.transaction.get"
+            Params = [txHash :> obj; true :> obj]
+        }
+        let json = Serialize obj
+        async {
+            let! resObj,_ = self.Request<BlockchainTransactionGetVerboseResult> json
             return resObj
         }
 

--- a/src/GWallet.Frontend.Console/Program.fs
+++ b/src/GWallet.Frontend.Console/Program.fs
@@ -483,8 +483,8 @@ let main argv =
     | 2 | 3 when argv.[0] = "--print-transactions" ->
         // --print-transactions <btcAddress> [maxTransactionsCount]
         if argv.Length = 2 then 
-            UtxoCoin.BtcTransactionPrinting.PrintTransactions UInt32.MaxValue argv.[1]
+            UtxoCoin.BtcTransactionPrinting.PrintTransactions None argv.[1]
         else
-            UtxoCoin.BtcTransactionPrinting.PrintTransactions (uint32 argv.[2]) argv.[1]
+            UtxoCoin.BtcTransactionPrinting.PrintTransactions (Some <| uint32 argv.[2]) argv.[1]
     | _ ->
         failwith "Arguments not recognized"

--- a/src/GWallet.Frontend.Console/Program.fs
+++ b/src/GWallet.Frontend.Console/Program.fs
@@ -480,5 +480,11 @@ let main argv =
         UpdateServersFile()
     | 1 when argv.[0] = "--update-servers-stats" ->
         UpdateServersStats()
+    | 2 | 3 when argv.[0] = "--print-transactions" ->
+        // --print-transactions <btcAddress> [maxTransactionsCount]
+        if argv.Length = 2 then 
+            UtxoCoin.BtcTransactionPrinting.PrintTransactions UInt32.MaxValue argv.[1]
+        else
+            UtxoCoin.BtcTransactionPrinting.PrintTransactions (uint32 argv.[2]) argv.[1]
     | _ ->
         failwith "Arguments not recognized"


### PR DESCRIPTION
Added `--print-transactions` option that for given Bitcoin
address prints all incoming transactions in reverse
chronological order.
Data printed: BTC amount, USD amount, date.