### PR TITLE
Frontend.Console: fix password confirm problem

### DIFF
--- a/src/GWallet.Frontend.Console/Program.fs
+++ b/src/GWallet.Frontend.Console/Program.fs
@@ -296,7 +296,7 @@ type private GenericWalletOption =
 
 let rec TestPaymentPassword () =
     let password = UserInteraction.AskPassword false
-    if Account.CheckValidPassword password None |> Async.RunSynchronously then
+    if Account.CheckValidPassword password None |> Async.RunSynchronously |> not then
         Console.WriteLine "Try again."
         TestPaymentPassword ()
 


### PR DESCRIPTION
Password confirmation returned successful when password was wrong, and returned with error when password was right.