### PR TITLE
GitHubCI: fix commitlint invocation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -319,15 +319,17 @@ jobs:
         # needed because of commit-lint, see https://github.com/conventional-changelog/commitlint/issues/3376
         fetch-depth: 0
     - name: Install dependencies of commitlint
-      run: sudo apt install --yes npm && npm install @commitlint/config-conventional
+      run: sudo apt install --yes npm
     - name: Pull our commitlint configuration
-      run: sudo apt install wget && wget https://raw.githubusercontent.com/nblockchain/conventions/master/commitlint.config.ts
+      run: |
+        git clone https://github.com/nblockchain/conventions.git
+        rm -rf ./conventions/.git/
     - name: Validate current commit (last commit) with commitlint
       if: github.event_name == 'push'
-      run: npx commitlint --from HEAD~1 --to HEAD --verbose
+      run: ./conventions/commitlint.sh --from HEAD~1 --to HEAD --verbose
     - name: Validate PR commits with commitlint
       if: github.event_name == 'pull_request'
-      run: npx commitlint --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose
+      run: ./conventions/commitlint.sh --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
   snap_pkg:
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -312,6 +312,18 @@ jobs:
 
   conventions:
     runs-on: ubuntu-20.04
+    needs:
+    - linux22-github
+    - linux22-github--newmono
+    - linux22-vanilla--stockmono
+    - linux22-vanilla--newmono
+    - linux20-github
+    - linux20-github--newmono
+    - linux20-vanilla--stockmono
+    - linux20-vanilla--newmono
+    - windows
+    - macOS
+
     steps:
     - uses: actions/checkout@v2
       with:
@@ -335,17 +347,6 @@ jobs:
 
     needs:
     - conventions
-
-    - linux22-github
-    - linux22-github--newmono
-    - linux22-vanilla--stockmono
-    - linux22-vanilla--newmono
-    - linux20-github
-    - linux20-github--newmono
-    - linux20-vanilla--stockmono
-    - linux20-vanilla--newmono
-    - windows
-    - macOS
 
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
We now use a script in conventions repo so that the invocation
approach can be defined there (because we've had to
downgrade to a previous version and we don't want all
consumers of conventions repo to need to know about this,
they can just call this script).