### PR TITLE
GitHubCI(conventions): move to vanilla VM

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -362,6 +362,8 @@ jobs:
 
   conventions:
     runs-on: ubuntu-20.04
+    container:
+      image: "ubuntu:22.04"
     needs:
     - linux22-github
     - linux22-github--newmono
@@ -376,13 +378,18 @@ jobs:
     - macOS
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
       with:
         submodules: false
-        # needed because of commit-lint, see https://github.com/conventional-changelog/commitlint/issues/3376
-        fetch-depth: 0
     - name: Install dependencies of commitlint
-      run: sudo apt install --yes npm
+      run: |
+        apt update
+        apt install --yes sudo
+
+        sudo apt install --yes git npm
+    # workaround for https://github.com/actions/runner/issues/2033
+    - name: ownership workaround
+      run: git config --global --add safe.directory '*'
     - name: Pull our commitlint configuration
       run: |
         git clone https://github.com/nblockchain/conventions.git


### PR DESCRIPTION
We keep getting CI errors because apt encounters (e.g. [1]) 503 HTTP error codes when trying to retrieve packages from the apt source. Example:

```
Get:288 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 npm all 6.14.4+ds-1ubuntu2 [583 kB]
Fetched 11.0 MB in 10s (1142 kB/s)
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/universe/n/node-form-data/node-form-data_3.0.0-2_all.deb  503  Service Unavailable [IP: 52.252.75.106 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```

By switching to a vanilla VM, we'll likely dodge this problem because the vanilla OS shouldn't have azure apt repos configured by default.

NOTE: after merging this, we get some scary warnings when running commitlint, but it seems to work fine. Example:

```
Run ./conventions/commitlint.sh --from HEAD~1 --to HEAD --verbose
++ dirname ./conventions/commitlint.sh
+ cd ./conventions
+ npm install
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@commitlint/cli@17.0.0',
npm WARN EBADENGINE   required: { node: '>=v14' },
npm WARN EBADENGINE   current: { node: 'v12.22.9', npm: '8.5.1' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@commitlint/config-validator@17.0.0',
npm WARN EBADENGINE   required: { node: '>=v14' },
npm WARN EBADENGINE   current: { node: 'v12.22.9', npm: '8.5.1' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@commitlint/ensure@17.0.0',
npm WARN EBADENGINE   required: { node: '>=v14' },
npm WARN EBADENGINE   current: { node: 'v12.22.9', npm: '8.5.1' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@commitlint/execute-rule@17.0.0',
npm WARN EBADENGINE   required: { node: '>=v14' },
npm WARN EBADENGINE   current: { node: 'v12.22.9', npm: '8.5.1' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@commitlint/format@17.0.0',
npm WARN EBADENGINE   required: { node: '>=v14' },
npm WARN EBADENGINE   current: { node: 'v12.22.9', npm: '8.5.1' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@commitlint/is-ignored@17.0.0',
npm WARN EBADENGINE   required: { node: '>=v14' },
npm WARN EBADENGINE   current: { node: 'v12.22.9', npm: '8.5.1' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@commitlint/lint@17.0.0',
npm WARN EBADENGINE   required: { node: '>=v14' },
npm WARN EBADENGINE   current: { node: 'v12.22.9', npm: '8.5.1' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@commitlint/load@17.0.0',
npm WARN EBADENGINE   required: { node: '>=v14' },
npm WARN EBADENGINE   current: { node: 'v12.22.9', npm: '8.5.1' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@commitlint/message@17.0.0',
npm WARN EBADENGINE   required: { node: '>=v14' },
npm WARN EBADENGINE   current: { node: 'v12.22.9', npm: '8.5.1' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'jest-leak-detector@29.3.1',
npm WARN EBADENGINE   required: { node: '^14.15.0 || ^16.10.0 || >=18.0.0' },
npm WARN EBADENGINE   current: { node: 'v12.22.9', npm: '8.5.1' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@jest/globals@29.3.1',
npm WARN EBADENGINE   required: { node: '^14.15.0 || ^16.10.0 || >=18.0.0' },
npm WARN EBADENGINE   current: { node: 'v12.22.9', npm: '8.5.1' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@jest/source-map@29.2.0',
npm WARN EBADENGINE   required: { node: '^14.15.0 || ^16.10.0 || >=18.0.0' },
npm WARN EBADENGINE   current: { node: 'v12.22.9', npm: '8.5.1' }
npm WARN EBADENGINE }

added 407 packages, and audited 408 packages in 15s

42 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
+ npx commitlint --version
@commitlint/cli@17.0.0
+ npx commitlint --from HEAD~1 --to HEAD --verbose
⧗   input: WIP3
⚠   type may not be empty [type-empty]

⚠   found 0 problems, 1 warnings
```

[1] https://github.com/nblockchain/geewallet/actions/runs/3880251886/jobs/6618246268