### PR TITLE
Backend.EtherServer: handle rpc exception -32001

### DIFF
--- a/src/GWallet.Backend/Ether/EtherExceptions.fs
+++ b/src/GWallet.Backend/Ether/EtherExceptions.fs
@@ -31,6 +31,7 @@ type RpcErrorCode =
     | EmptyResponse = -32042
     | DailyRequestCountExceededSoRequestRateLimited = -32005
     | CannotFulfillRequest = -32046
+    | ResourceNotFound = -32001
 
 type ServerCannotBeResolvedException =
     inherit CommunicationUnsuccessfulException

--- a/src/GWallet.Backend/Ether/EtherServer.fs
+++ b/src/GWallet.Backend/Ether/EtherServer.fs
@@ -220,6 +220,8 @@ module Server =
                     raise <| ServerRefusedException(exMsg, rpcResponseEx)
                 | g when g = int RpcErrorCode.CannotFulfillRequest ->
                     raise <| ServerRefusedException(exMsg, rpcResponseEx)
+                | h when h = int RpcErrorCode.ResourceNotFound ->
+                    raise <| ServerMisconfiguredException(exMsg, rpcResponseEx)
                 | _ ->
                     raise
                     <| Exception (SPrintF3 "RpcResponseException with RpcError Code <%i> and Message '%s' (%s)"


### PR DESCRIPTION
Catch RpcResponseException resource not found with error code -32001. This error happened in integration tests and it's stacktrace is:

```
Unhandled Exception: System.AggregateException: One or more errors occurred. ---> System.Exception: Some problem when connecting to 'cloudflare-eth.com/' ---> System.Exception: RpcResponseException with RpcError Code <-32001> and Message 'Resource not found.' (Resource not found.) ---> JsonRpcSharp.Client.RpcResponseException: Resource not found.
   at JsonRpcSharp.Client.ClientBase.HandleRpcError(RpcResponseMessage response)
   at JsonRpcSharp.Client.ClientBase.<SendInnerRequestAsync>d__11`1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at JsonRpcSharp.Client.ClientBase.<SendInnerRequestAsync>d__12`1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at JsonRpcSharp.Client.ClientBase.<SendRequestAsync>d__8`1.MoveNext()
   --- End of inner exception stack trace ---
   at GWallet.Backend.Ether.Server.MaybeRethrowRpcResponseException(Exception ex) in D:\a\geewallet\geewallet\src\GWallet.Backend\Ether\EtherServer.fs:line 233
   at GWallet.Backend.Ether.Server.ReworkException(Exception ex) in D:\a\geewallet\geewallet\src\GWallet.Backend\Ether\EtherServer.fs:line 322
   at GWallet.Backend.Ether.Server.HandlePossibleEtherFailures@410-6.Invoke(Exception _arg2) in D:\a\geewallet\geewallet\src\GWallet.Backend\Ether\EtherServer.fs:line 415
   at GWallet.Backend.Ether.Server.HandlePossibleEtherFailures@410-8.Invoke(Exception exn) in D:\a\geewallet\geewallet\src\GWallet.Backend\Ether\EtherServer.fs:line 410
   at GWallet.Backend.Ether.Server.HandlePossibleEtherFailures@410-10.Invoke(Exception edi) in D:\a\geewallet\geewallet\src\GWallet.Backend\Ether\EtherServer.fs:line 410
   at Microsoft.FSharp.Control.AsyncPrimitives.CallFilterThenInvoke[T](AsyncActivation`1 ctxt, FSharpFunc`2 catchFilter, ExceptionDispatchInfo edi)
   at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc`2 firstAction)
   --- End of inner exception stack trace ---
   at GWallet.Backend.Ether.Server.Web3ServerToRetrievalFunc@429-2.Invoke(Exception _arg3) in D:\a\geewallet\geewallet\src\GWallet.Backend\Ether\EtherServer.fs:line 438
   at GWallet.Backend.Ether.Server.Web3ServerToRetrievalFunc@429-5.Invoke(Exception exn) in D:\a\geewallet\geewallet\src\GWallet.Backend\Ether\EtherServer.fs:line 429
   at GWallet.Backend.Ether.Server.Web3ServerToRetrievalFunc@429-7.Invoke(Exception edi) in D:\a\geewallet\geewallet\src\GWallet.Backend\Ether\EtherServer.fs:line 429
   at Microsoft.FSharp.Control.AsyncPrimitives.CallFilterThenInvoke[T](AsyncActivation`1 ctxt, FSharpFunc`2 catchFilter, ExceptionDispatchInfo edi)
   at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc`2 firstAction)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at Fsdk.FSharpUtil.ReRaise(Exception ex)
   at <StartupCode$GWallet-Backend>.$FaultTolerantParallelClient.Run@138-8.Invoke(Exception _arg2) in D:\a\geewallet\geewallet\src\GWallet.Backend\FaultTolerantParallelClient.fs:line 167
   at <StartupCode$GWallet-Backend>.$FaultTolerantParallelClient.Run@138-15.Invoke(Exception exn) in D:\a\geewallet\geewallet\src\GWallet.Backend\FaultTolerantParallelClient.fs:line 138
   at <StartupCode$GWallet-Backend>.$FaultTolerantParallelClient.Run@138-17.Invoke(Exception edi) in D:\a\geewallet\geewallet\src\GWallet.Backend\FaultTolerantParallelClient.fs:line 138
   at Microsoft.FSharp.Control.AsyncPrimitives.CallFilterThenInvoke[T](AsyncActivation`1 ctxt, FSharpFunc`2 catchFilter, ExceptionDispatchInfo edi)
   at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc`2 firstAction)
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
   at System.Threading.Tasks.Task`1.get_Result()
   at <StartupCode$GWallet-Backend>.$FaultTolerantParallelClient.clo@314-29.Invoke(ServerTask`2 _arg1) in D:\a\geewallet\geewallet\src\GWallet.Backend\FaultTolerantParallelClient.fs:line 318
   at Microsoft.FSharp.Control.AsyncPrimitives.CallThenInvokeNoHijackCheck[a,b](AsyncActivation`1 ctxt, FSharpFunc`2 userCode, b result1)
   at <StartupCode$GWallet-Backend>.$FaultTolerantParallelClient.WhenAny@120-2.Invoke(AsyncActivation`1 ctxt) in D:\a\geewallet\geewallet\src\GWallet.Backend\FaultTolerantParallelClient.fs:line 120
   at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc`2 firstAction)
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.FSharp.Control.AsyncResult`1.Commit()
   at Microsoft.FSharp.Control.AsyncPrimitives.RunSynchronouslyInCurrentThread[a](CancellationToken cancellationToken, FSharpAsync`1 computation)
   at Microsoft.FSharp.Control.AsyncPrimitives.RunSynchronously[T](CancellationToken cancellationToken, FSharpAsync`1 computation, FSharpOption`1 timeout)
   at Microsoft.FSharp.Control.FSharpAsync.RunSynchronously[T](FSharpAsync`1 computation, FSharpOption`1 timeout, FSharpOption`1 cancellationToken)
   at GWallet.Backend.ServerManager.UpdateServersStats() in D:\a\geewallet\geewallet\src\GWallet.Backend\ServerManager.fs:line 171
   at Program.UpdateServersStats() in D:\a\geewallet\geewallet\src\GWallet.Frontend.Console\Program.fs:line 468
   at Program.main(String[] argv) in D:\a\geewallet\geewallet\src\GWallet.Frontend.Console\Program.fs:line 482
```