### PR TITLE
Backend: remove unused XE dependency

### DIFF
--- a/src/GWallet.Backend/Config.fs
+++ b/src/GWallet.Backend/Config.fs
@@ -6,7 +6,6 @@ open System.Linq
 open System.Reflection
 open System.Runtime.InteropServices
 
-open Xamarin.Essentials
 open Fsdk
 
 open GWallet.Backend.FSharpUtil.UwpHacks

--- a/src/GWallet.Backend/GWallet.Backend.fsproj
+++ b/src/GWallet.Backend/GWallet.Backend.fsproj
@@ -56,9 +56,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2">
       <GeneratePathProperty></GeneratePathProperty>
     </PackageReference>
-    <PackageReference Include="Xamarin.Essentials" Version="1.0.0">
-      <GeneratePathProperty></GeneratePathProperty>
-    </PackageReference>
     <PackageReference Include="NBitcoin" Version="6.0.17">
       <GeneratePathProperty></GeneratePathProperty>
     </PackageReference>


### PR DESCRIPTION
This commit removes the now unused dependency to
Xamarin.Essentials which was introduced in https://github.com/nblockchain/geewallet/commit/97d580050c8baac3b0cebc602fa5fb57c92014b8 and went out of use in https://github.com/nblockchain/geewallet/commit/9dd3f9e65ec830850cf12ed1fa91d1799518b3b1.

For future references adding XE to Backend can cause problems with MAUI because it adds Xamarin.Android.Support.V4 as dependency which conflicts with MAUI's AndroidX dependency.