### PR TITLE
Backend: pin FSharp.Core in JsonRpcSharp

### DIFF
--- a/src/GWallet.Backend/GWallet.Backend.fsproj
+++ b/src/GWallet.Backend/GWallet.Backend.fsproj
@@ -197,7 +197,7 @@
       <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.1.0.2\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="JsonRpcSharp.TcpClient">
-      <HintPath>..\..\packages\JsonRpcSharp.0.98.0--date20230731-0834.git-7444c06\lib\netstandard2.0\JsonRpcSharp.TcpClient.dll</HintPath>
+      <HintPath>..\..\packages\JsonRpcSharp.0.98.0--date20230731-1252.git-6788e32\lib\netstandard2.0\JsonRpcSharp.TcpClient.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.Pipes">
       <HintPath>..\..\packages\System.IO.Pipes.4.3.0\lib\net46\System.IO.Pipes.dll</HintPath>
@@ -209,16 +209,16 @@
       <HintPath>..\..\packages\System.Net.WebSockets.Client.4.3.2\lib\net46\System.Net.WebSockets.Client.dll</HintPath>
     </Reference>
     <Reference Include="JsonRpcSharp.Client">
-      <HintPath>..\..\packages\JsonRpcSharp.0.98.0--date20230731-0834.git-7444c06\lib\netstandard2.0\JsonRpcSharp.Client.dll</HintPath>
+      <HintPath>..\..\packages\JsonRpcSharp.0.98.0--date20230731-1252.git-6788e32\lib\netstandard2.0\JsonRpcSharp.Client.dll</HintPath>
     </Reference>
     <Reference Include="JsonRpcSharp.IpcClient">
-      <HintPath>..\..\packages\JsonRpcSharp.0.98.0--date20230731-0834.git-7444c06\lib\netstandard2.0\JsonRpcSharp.IpcClient.dll</HintPath>
+      <HintPath>..\..\packages\JsonRpcSharp.0.98.0--date20230731-1252.git-6788e32\lib\netstandard2.0\JsonRpcSharp.IpcClient.dll</HintPath>
     </Reference>
     <Reference Include="JsonRpcSharp.HttpClient">
-      <HintPath>..\..\packages\JsonRpcSharp.0.98.0--date20230731-0834.git-7444c06\lib\netstandard2.0\JsonRpcSharp.HttpClient.dll</HintPath>
+      <HintPath>..\..\packages\JsonRpcSharp.0.98.0--date20230731-1252.git-6788e32\lib\netstandard2.0\JsonRpcSharp.HttpClient.dll</HintPath>
     </Reference>
     <Reference Include="JsonRpcSharp.WebSocketClient">
-      <HintPath>..\..\packages\JsonRpcSharp.0.98.0--date20230731-0834.git-7444c06\lib\netstandard2.0\JsonRpcSharp.WebSocketClient.dll</HintPath>
+      <HintPath>..\..\packages\JsonRpcSharp.0.98.0--date20230731-1252.git-6788e32\lib\netstandard2.0\JsonRpcSharp.WebSocketClient.dll</HintPath>
     </Reference>
     <Reference Include="Nethereum.ABI">
       <HintPath>..\..\packages\Nethereum.0.95.0--date20210125-0551.git-05a29e9\lib\netstandard2.0\Nethereum.ABI.dll</HintPath>

--- a/src/GWallet.Backend/packages.config
+++ b/src/GWallet.Backend/packages.config
@@ -4,7 +4,7 @@
   <package id="FSharp.Core" version="4.7.0" targetFramework="net461" />
   <package id="FSharp.Data" version="3.0.0" targetFramework="net46" />
   <package id="HtmlAgilityPack" version="1.11.24" targetFramework="net471" />
-  <package id="JsonRpcSharp" version="0.98.0--date20230731-0834.git-7444c06" targetFramework="net461" />
+  <package id="JsonRpcSharp" version="0.98.0--date20230731-1252.git-6788e32" targetFramework="net461" />
   <package id="Microsoft.CSharp" version="4.0.1" targetFramework="net46" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="1.0.2" targetFramework="net46" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net46" />


### PR DESCRIPTION
This commit updates the JsonRpcSharp library which
uses an older version of FSharp.Core.

This fixes the FSharp.Core version conflict
problem caused by [1] which was trying to fix
integration tests in [2].

[1]
https://github.com/nblockchain/geewallet/commit/3bcde0b8ed24bc91d498a34bf887b5dd08b53af3
[2]
https://github.com/nblockchain/geewallet/commit/9392215bfa6c0f625ddce6423b3bf77a0dea8558
