### PR TITLE
Backend.Tests: add missing packages.config ref

### DIFF
--- a/src/GWallet.Backend.Tests/packages.config
+++ b/src/GWallet.Backend.Tests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FSharp.Core" version="4.7.0" targetFramework="net461" />
+  <package id="Fsdk" version="0.6.0--date20230530-1155.git-3bb8d08" targetFramework="net46" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="1.0.2" targetFramework="net46" />
   <package id="NBitcoin" version="6.0.17" targetFramework="net471" />
   <package id="NBitcoin.Altcoins" version="3.0.8" targetFramework="net452" />


### PR DESCRIPTION
While Fsdk is referenced in fsproj file it was not present in packages.config, it did not cause red CI because Fsdk was referenced in another packages.config file.