### PR TITLE
GWallet.Backend: move legacy obj path

### DIFF
--- a/src/GWallet.Backend/GWallet.Backend-legacy.fsproj
+++ b/src/GWallet.Backend/GWallet.Backend-legacy.fsproj
@@ -18,6 +18,7 @@
         /warnon:3218
         /warnon:0193
     </OtherFlags>
+    <BaseIntermediateOutputPath>obj\legacy\</BaseIntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Using the same folder for two project that use different frameworks, causes problems due to incompatible caches in obj folder, this commit fixes that by moving the cache folder for the legacy version.