### PR TITLE
Frontend.XF.*: fix references in .fsproj files

### DIFF
--- a/src/GWallet.Frontend.XF.Android/GWallet.Frontend.XF.Android.fsproj
+++ b/src/GWallet.Frontend.XF.Android/GWallet.Frontend.XF.Android.fsproj
@@ -507,6 +507,7 @@
       <Name>GWallet.Frontend.XF</Name>
     </ProjectReference>
     <ProjectReference Include="..\GWallet.Backend\GWallet.Backend.fsproj">
+      <Project>{96F9B3E5-11F8-4F5F-AADC-51D0D995B3D2}</Project>	
       <Name>GWallet.Backend</Name>
     </ProjectReference>
   </ItemGroup>

--- a/src/GWallet.Frontend.XF.Gtk/GWallet.Frontend.XF.Gtk.fsproj
+++ b/src/GWallet.Frontend.XF.Gtk/GWallet.Frontend.XF.Gtk.fsproj
@@ -251,6 +251,7 @@
       <Name>GWallet.Frontend.XF</Name>
     </ProjectReference>
     <ProjectReference Condition="'$(TwoPhaseBuildDueToXBuildUsage)'!='true'" Include="..\GWallet.Backend\GWallet.Backend.fsproj">
+      <Project>{96F9B3E5-11F8-4F5F-AADC-51D0D995B3D2}</Project>
       <Name>GWallet.Backend</Name>
     </ProjectReference>
     <None Include="webkit-sharp.dll.config" />

--- a/src/GWallet.Frontend.XF.Mac/GWallet.Frontend.XF.Mac.fsproj
+++ b/src/GWallet.Frontend.XF.Mac/GWallet.Frontend.XF.Mac.fsproj
@@ -212,6 +212,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GWallet.Backend\GWallet.Backend.fsproj">
+      <Project>{96F9B3E5-11F8-4F5F-AADC-51D0D995B3D2}</Project>
       <Name>GWallet.Backend</Name>
     </ProjectReference>
     <ProjectReference Include="..\GWallet.Frontend.XF\GWallet.Frontend.XF.fsproj">

--- a/src/GWallet.Frontend.XF.iOS/GWallet.Frontend.XF.iOS.fsproj
+++ b/src/GWallet.Frontend.XF.iOS/GWallet.Frontend.XF.iOS.fsproj
@@ -209,6 +209,7 @@
       <Name>GWallet.Frontend.XF</Name>
     </ProjectReference>
     <ProjectReference Include="..\GWallet.Backend\GWallet.Backend.fsproj">
+      <Project>{96F9B3E5-11F8-4F5F-AADC-51D0D995B3D2}</Project>
       <Name>GWallet.Backend</Name>
     </ProjectReference>
     <Reference Include="FSharp.Data">


### PR DESCRIPTION
Fix project references in Fronend.XF.*.fsproj files by adding `<Project>` element with project guid to each project reference. This is needed to avoid "error  : Unrecognized Guid format" error when loading projects in Visual Studio 2022.