### PR TITLE
sln: remove fsdk nested proj from solution

### DIFF
--- a/geewallet.sln
+++ b/geewallet.sln
@@ -281,9 +281,6 @@ Global
 		{5DD656CE-3319-46BB-B47F-BBED8CC722FD}.Release|x86.ActiveCfg = Release|iPhoneSimulator
 		{5DD656CE-3319-46BB-B47F-BBED8CC722FD}.Release|x86.Build.0 = Release|iPhoneSimulator
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{6EE07541-91A1-42C2-A21F-2809BBDC2F50} = {CE79AB9D-0FB9-4606-B7C6-A78C0858CC54}
-	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
This commit fixes this error when restoring geewallet.sln projects:
```
C:\geewallet\geewallet.sln : Solution file error MSB5009:
Error parsing the project "Fsdk" section with GUID: "{6EE0754
1-91A1-42C2-A21F-2809BBDC2F50}". It is nested under
"{CE79AB9D-0FB9-4606-B7C6-A78C0858CC54}" but that project is not fo
und in the solution.
```