### PR TITLE
FE.XF.GTK: open console app with --console arg

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,5 +1,8 @@
 # NOTE: newer commits are above, older ones below
 
+# Frontend.Console: stop using moduleless funcs
+ccdb07a040167b8e405d837c08e4b482ab8f3b25
+
 # Frontend.XF: cosmetic, replace this with self
 55fd9692099943d09504376354e7f085cfa75cfc
 

--- a/scripts/make.fsx
+++ b/scripts/make.fsx
@@ -27,12 +27,14 @@ let CONSOLE_FRONTEND = "GWallet.Frontend.Console"
 let GTK_FRONTEND = "GWallet.Frontend.XF.Gtk"
 
 type ProjectFile =
+    | ConsoleFrontend
     | XFFrontend
     | GtkFrontend
 
 let GetProject (projFile: ProjectFile) =
     let projFileName =
         match projFile with
+        | ConsoleFrontend -> Path.Combine("GWallet.Frontend.Console", "GWallet.Frontend.Console.fsproj")
         | GtkFrontend -> Path.Combine("GWallet.Frontend.XF.Gtk", "GWallet.Frontend.XF.Gtk.fsproj")
         | XFFrontend -> Path.Combine("GWallet.Frontend.XF", "GWallet.Frontend.XF.fsproj")
 
@@ -331,6 +333,15 @@ let JustBuild binaryConfig maybeConstant: Frontend*FileInfo =
                 BuildSolutionOrProject
                     (getBuildToolAndArgs buildTool)
                     (GetProject ProjectFile.XFFrontend)
+                    binaryConfig
+                    maybeConstant
+                    String.Empty
+ 
+                let buildAsLibraryFlag = "build /property:BuildFrontendConsoleAsLibrary=true"
+
+                BuildSolutionOrProject
+                    (buildTool, buildAsLibraryFlag)
+                    (GetProject ProjectFile.ConsoleFrontend)
                     binaryConfig
                     maybeConstant
                     String.Empty

--- a/scripts/make.fsx
+++ b/scripts/make.fsx
@@ -23,8 +23,9 @@ open Fsdk.Process
 open GWallet.Scripting
 
 let UNIX_NAME = "geewallet"
-let CONSOLE_FRONTEND = "GWallet.Frontend.Console"
-let GTK_FRONTEND = "GWallet.Frontend.XF.Gtk"
+let SHORT_NAME = "GWallet"
+let CONSOLE_FRONTEND = sprintf "%s.Frontend.Console" SHORT_NAME
+let GTK_FRONTEND = sprintf "%s.Frontend.XF.Gtk" SHORT_NAME
 
 type ProjectFile =
     | ConsoleFrontend
@@ -34,18 +35,18 @@ type ProjectFile =
 let GetProject (projFile: ProjectFile) =
     let projFileName =
         match projFile with
-        | ConsoleFrontend -> Path.Combine("GWallet.Frontend.Console", "GWallet.Frontend.Console.fsproj")
-        | GtkFrontend -> Path.Combine("GWallet.Frontend.XF.Gtk", "GWallet.Frontend.XF.Gtk.fsproj")
-        | XFFrontend -> Path.Combine("GWallet.Frontend.XF", "GWallet.Frontend.XF.fsproj")
+        | ConsoleFrontend -> sprintf "%s.Frontend.Console" SHORT_NAME
+        | GtkFrontend -> sprintf "%s.Frontend.XF.Gtk" SHORT_NAME
+        | XFFrontend -> sprintf "%s.Frontend.XF" SHORT_NAME
 
     let prjFile =
-        Path.Combine("src", projFileName)
+        Path.Combine("src", projFileName, sprintf "%s.fsproj" projFileName)
         |> FileInfo
     if not prjFile.Exists then
         raise <| FileNotFoundException("Project file not found", prjFile.FullName)
     prjFile
 
-let BACKEND = "GWallet.Backend"
+let BACKEND = sprintf "%s.Backend" SHORT_NAME
 
 type Frontend =
     | Console
@@ -512,7 +513,7 @@ match maybeTarget with
     Console.WriteLine "Running tests..."
     Console.WriteLine ()
 
-    let testProjectName = "GWallet.Backend.Tests"
+    let testProjectName = sprintf "%s.Backend.Tests" SHORT_NAME
 #if !LEGACY_FRAMEWORK
     let testTarget =
         Path.Combine (

--- a/src/GWallet.Frontend.Console/GWallet.Frontend.Console.fsproj
+++ b/src/GWallet.Frontend.Console/GWallet.Frontend.Console.fsproj
@@ -1,8 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
+  <Choose>
+    <When Condition="'$(BuildFrontendConsoleAsLibrary)'=='true' Or '$(MSBuildRuntimeType)'=='Mono'">
+      <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
   <ItemGroup>
     <Compile Include="..\GWallet.Backend\Properties\CommonAssemblyInfo.fs">
       <Link>Properties\CommonAssemblyInfo.fs</Link>

--- a/src/GWallet.Frontend.Console/Program.fs
+++ b/src/GWallet.Frontend.Console/Program.fs
@@ -1,4 +1,6 @@
-﻿open System
+﻿namespace GWallet.Frontend.Console
+
+open System
 open System.IO
 open System.Linq
 open System.Text.RegularExpressions
@@ -6,529 +8,531 @@ open System.Text.RegularExpressions
 open GWallet.Backend
 open GWallet.Frontend.Console
 
-let SendWithMinerFeeValidation (sendPaymentFunc: bool -> unit) =
-    try
-        sendPaymentFunc false
+module Program =
 
-        UserInteraction.PressAnyKeyToContinue ()
-    with
-    | :? MinerFeeHigherThanOutputs ->
-        let userWantsToContinue =
-            UserInteraction.AskYesNo "Miner fee is higher than amount transferred, are you ABSOLUTELY sure you want to broadcast?"
-        if userWantsToContinue then
-            sendPaymentFunc true
-
-        UserInteraction.PressAnyKeyToContinue ()
-
-let rec TrySendAmount (account: NormalAccount) transactionMetadata destination amount =
-    let password = UserInteraction.AskPassword false
-
-    let sendPayment ignoreHigherMinerFeeThanAmount =
-        let txIdUri =
-            Account.SendPayment account transactionMetadata destination amount password ignoreHigherMinerFeeThanAmount
-                |> Async.RunSynchronously
-        Console.WriteLine(sprintf "Transaction successful:%s%s" Environment.NewLine (txIdUri.ToString()))
-
-    try
-        SendWithMinerFeeValidation sendPayment
-    with
-    | :? DestinationEqualToOrigin ->
-        Presentation.Error "Transaction's origin cannot be the same as the destination."
-        UserInteraction.PressAnyKeyToContinue()
-    | :? InsufficientFunds ->
-        Presentation.Error "Insufficient funds."
-        UserInteraction.PressAnyKeyToContinue()
-    | :? InvalidPassword ->
-        Presentation.Error "Invalid password, try again."
-        TrySendAmount account transactionMetadata destination amount
-
-let rec TrySign account unsignedTrans =
-    let password = UserInteraction.AskPassword false
-    try
-        Account.SignUnsignedTransaction account unsignedTrans password
-    with
-    // TODO: would this throw insufficient funds? test
-    //| :? InsufficientFunds ->
-    //    Presentation.Error "Insufficient funds."
-    | :? InvalidPassword ->
-        Presentation.Error "Invalid password, try again."
-        TrySign account unsignedTrans
-
-let BroadcastPayment() =
-    let fileToReadFrom = UserInteraction.AskFileNameToLoad
-                             "Introduce a file name to load the signed transaction: "
-    let signedTransactionOpt =
+    let SendWithMinerFeeValidation (sendPaymentFunc: bool -> unit) =
         try
-            Account.LoadSignedTransactionFromFile fileToReadFrom.FullName
-            |> Some
+            sendPaymentFunc false
+
+            UserInteraction.PressAnyKeyToContinue ()
         with
-        | TransactionNotSignedYet ->
-            None
+        | :? MinerFeeHigherThanOutputs ->
+            let userWantsToContinue =
+                UserInteraction.AskYesNo "Miner fee is higher than amount transferred, are you ABSOLUTELY sure you want to broadcast?"
+            if userWantsToContinue then
+                sendPaymentFunc true
 
-    //TODO: check if nonce matches, if not, reject trans
+            UserInteraction.PressAnyKeyToContinue ()
 
-    match signedTransactionOpt with
-    | None ->
-        Console.WriteLine String.Empty
-        Presentation.Error "The transaction hasn't been signed yet."
-        Console.WriteLine (
-            sprintf
-                "You maybe forgot to use the option '%s' on the offline device."
-                (Presentation.ConvertPascalCaseToSentence (Operations.SignOffPayment.ToString()))
-        )
-        UserInteraction.PressAnyKeyToContinue ()
+    let rec TrySendAmount (account: NormalAccount) transactionMetadata destination amount =
+        let password = UserInteraction.AskPassword false
 
-    | Some signedTransaction ->
-        let transactionDetails = Account.GetSignedTransactionDetails signedTransaction
-        Presentation.ShowTransactionData
-            transactionDetails
-            signedTransaction.TransactionInfo.Metadata
+        let sendPayment ignoreHigherMinerFeeThanAmount =
+            let txIdUri =
+                Account.SendPayment account transactionMetadata destination amount password ignoreHigherMinerFeeThanAmount
+                    |> Async.RunSynchronously
+            Console.WriteLine(sprintf "Transaction successful:%s%s" Environment.NewLine (txIdUri.ToString()))
 
-        if UserInteraction.AskYesNo "Do you accept?" then
+        try
+            SendWithMinerFeeValidation sendPayment
+        with
+        | :? DestinationEqualToOrigin ->
+            Presentation.Error "Transaction's origin cannot be the same as the destination."
+            UserInteraction.PressAnyKeyToContinue()
+        | :? InsufficientFunds ->
+            Presentation.Error "Insufficient funds."
+            UserInteraction.PressAnyKeyToContinue()
+        | :? InvalidPassword ->
+            Presentation.Error "Invalid password, try again."
+            TrySendAmount account transactionMetadata destination amount
+
+    let rec TrySign account unsignedTrans =
+        let password = UserInteraction.AskPassword false
+        try
+            Account.SignUnsignedTransaction account unsignedTrans password
+        with
+        // TODO: would this throw insufficient funds? test
+        //| :? InsufficientFunds ->
+        //    Presentation.Error "Insufficient funds."
+        | :? InvalidPassword ->
+            Presentation.Error "Invalid password, try again."
+            TrySign account unsignedTrans
+
+    let BroadcastPayment() =
+        let fileToReadFrom = UserInteraction.AskFileNameToLoad
+                                 "Introduce a file name to load the signed transaction: "
+        let signedTransactionOpt =
             try
-                let broadcastTx ignoreHigherMinerFeeThanAmount =
-                    let txIdUri =
-                        Account.BroadcastTransaction signedTransaction ignoreHigherMinerFeeThanAmount
-                            |> Async.RunSynchronously
-                    Console.WriteLine(sprintf "Transaction successful:%s%s" Environment.NewLine (txIdUri.ToString()))
-
-                SendWithMinerFeeValidation broadcastTx
+                Account.LoadSignedTransactionFromFile fileToReadFrom.FullName
+                |> Some
             with
-            | :? DestinationEqualToOrigin ->
-                Presentation.Error "Transaction's origin cannot be the same as the destination."
-                UserInteraction.PressAnyKeyToContinue()
-            | :? InsufficientFunds ->
-                Presentation.Error "Insufficient funds."
-                UserInteraction.PressAnyKeyToContinue()
+            | TransactionNotSignedYet ->
+                None
 
-let SignOffPayment() =
-    let fileToReadFrom = UserInteraction.AskFileNameToLoad
-                             "Introduce a file name to load the unsigned transaction: "
-    let unsignedTransactionOpt =
-        try
-            let unsTx = Account.LoadUnsignedTransactionFromFile fileToReadFrom.FullName
-            let accountsWithSameAddress =
-                Account.GetAllActiveAccounts().Where(
-                    fun acc -> acc.PublicAddress = unsTx.Proposal.OriginMainAddress
-                )
-            Some (unsTx, accountsWithSameAddress)
-        with
-        | TransactionAlreadySigned ->
-            None
+        //TODO: check if nonce matches, if not, reject trans
 
-    match unsignedTransactionOpt with
-    | None ->
-        Console.WriteLine String.Empty
-        Presentation.Error "The transaction is already signed."
-        Console.WriteLine (
-            sprintf
-                "You maybe wanted to use the option '%s'."
-                (Presentation.ConvertPascalCaseToSentence (Operations.BroadcastPayment.ToString()))
-        )
-        UserInteraction.PressAnyKeyToContinue ()
-
-    | Some (_, accountsWithSameAddress) when not (accountsWithSameAddress.Any()) ->
-        Presentation.Error "The transaction doesn't correspond to any of the accounts in the wallet."
-        UserInteraction.PressAnyKeyToContinue ()
-
-    | Some (unsignedTransaction, accountsWithSameAddress) ->
-        let accounts =
-            accountsWithSameAddress.Where(
-                fun acc -> acc.Currency = unsignedTransaction.Proposal.Amount.Currency &&
-                           acc :? NormalAccount)
-        if not (accounts.Any()) then
-            Presentation.Error(
+        match signedTransactionOpt with
+        | None ->
+            Console.WriteLine String.Empty
+            Presentation.Error "The transaction hasn't been signed yet."
+            Console.WriteLine (
                 sprintf
-                    "The transaction corresponds to an address of the accounts in this wallet, but it's a readonly account or it maps a different currency than %A."
-                    unsignedTransaction.Proposal.Amount.Currency
+                    "You maybe forgot to use the option '%s' on the offline device."
+                    (Presentation.ConvertPascalCaseToSentence (Operations.SignOffPayment.ToString()))
+            )
+            UserInteraction.PressAnyKeyToContinue ()
+
+        | Some signedTransaction ->
+            let transactionDetails = Account.GetSignedTransactionDetails signedTransaction
+            Presentation.ShowTransactionData
+                transactionDetails
+                signedTransaction.TransactionInfo.Metadata
+
+            if UserInteraction.AskYesNo "Do you accept?" then
+                try
+                    let broadcastTx ignoreHigherMinerFeeThanAmount =
+                        let txIdUri =
+                            Account.BroadcastTransaction signedTransaction ignoreHigherMinerFeeThanAmount
+                                |> Async.RunSynchronously
+                        Console.WriteLine(sprintf "Transaction successful:%s%s" Environment.NewLine (txIdUri.ToString()))
+
+                    SendWithMinerFeeValidation broadcastTx
+                with
+                | :? DestinationEqualToOrigin ->
+                    Presentation.Error "Transaction's origin cannot be the same as the destination."
+                    UserInteraction.PressAnyKeyToContinue()
+                | :? InsufficientFunds ->
+                    Presentation.Error "Insufficient funds."
+                    UserInteraction.PressAnyKeyToContinue()
+
+    let SignOffPayment() =
+        let fileToReadFrom = UserInteraction.AskFileNameToLoad
+                                 "Introduce a file name to load the unsigned transaction: "
+        let unsignedTransactionOpt =
+            try
+                let unsTx = Account.LoadUnsignedTransactionFromFile fileToReadFrom.FullName
+                let accountsWithSameAddress =
+                    Account.GetAllActiveAccounts().Where(
+                        fun acc -> acc.PublicAddress = unsTx.Proposal.OriginMainAddress
+                    )
+                Some (unsTx, accountsWithSameAddress)
+            with
+            | TransactionAlreadySigned ->
+                None
+
+        match unsignedTransactionOpt with
+        | None ->
+            Console.WriteLine String.Empty
+            Presentation.Error "The transaction is already signed."
+            Console.WriteLine (
+                sprintf
+                    "You maybe wanted to use the option '%s'."
+                    (Presentation.ConvertPascalCaseToSentence (Operations.BroadcastPayment.ToString()))
+            )
+            UserInteraction.PressAnyKeyToContinue ()
+
+        | Some (_, accountsWithSameAddress) when not (accountsWithSameAddress.Any()) ->
+            Presentation.Error "The transaction doesn't correspond to any of the accounts in the wallet."
+            UserInteraction.PressAnyKeyToContinue ()
+
+        | Some (unsignedTransaction, accountsWithSameAddress) ->
+            let accounts =
+                accountsWithSameAddress.Where(
+                    fun acc -> acc.Currency = unsignedTransaction.Proposal.Amount.Currency &&
+                               acc :? NormalAccount)
+            if not (accounts.Any()) then
+                Presentation.Error(
+                    sprintf
+                        "The transaction corresponds to an address of the accounts in this wallet, but it's a readonly account or it maps a different currency than %A."
+                        unsignedTransaction.Proposal.Amount.Currency
+                )
+                UserInteraction.PressAnyKeyToContinue()
+            else
+                let account = accounts.First()
+                if (accounts.Count() > 1) then
+                    failwith "More than one normal account matching address and currency? Please report this issue."
+
+                match account with
+                | :? ReadOnlyAccount ->
+                    failwith "Previous account filtering should have discarded readonly accounts already. Please report this issue"
+                | :? NormalAccount as normalAccount ->
+                    Console.WriteLine ("Importing external data...")
+                    Caching.Instance.SaveSnapshot unsignedTransaction.Cache
+
+                    let lines = UserInteraction.DisplayAccountStatuses <| WhichAccount.MatchingWith account
+                                   |> Async.RunSynchronously
+                    Console.WriteLine ("Account to use when signing off this transaction:")
+                    Console.WriteLine ()
+                    for line in lines do
+                        Console.WriteLine line
+                    Console.WriteLine()
+
+                    Presentation.ShowTransactionData
+                        (unsignedTransaction.Proposal :> ITransactionDetails)
+                        unsignedTransaction.Metadata
+
+                    if UserInteraction.AskYesNo "Do you accept?" then
+                        let trans = TrySign normalAccount unsignedTransaction
+                        Console.WriteLine("Transaction signed.")
+                        Console.Write("Introduce a file name or path to save it: ")
+                        let filePathToSaveTo = Console.ReadLine()
+                        Account.SaveSignedTransaction trans filePathToSaveTo
+                        Console.WriteLine("Transaction signed and saved successfully. Now copy it to the online device.")
+                        UserInteraction.PressAnyKeyToContinue ()
+                | _ ->
+                    failwith "Account type not supported. Please report this issue."
+
+    let TryConsumeJson func =
+        try
+            func()
+        with
+        | :? VersionMismatchDuringDeserializationException ->
+            Console.WriteLine()
+            Console.Error.WriteLine "There was an error (caused by a version mismatch) when trying to consume JSON;
+    it is recommended to upgrade (both the hotwallet and the offline coldwallet)"
+            UserInteraction.PressAnyKeyToContinue()
+
+    let SendPaymentOfSpecificAmount (account: IAccount)
+                                    (amount: TransferAmount)
+                                    (transactionMetadata: IBlockchainFeeInfo)
+                                    (destination: string) =
+        match account with
+        | :? ReadOnlyAccount ->
+            Console.WriteLine("Cannot send payments from readonly accounts.")
+            Console.Write("Introduce a file name to save the unsigned transaction: ")
+            let filePath = Console.ReadLine()
+            let proposal = {
+                OriginMainAddress = account.PublicAddress;
+                Amount = amount;
+                DestinationAddress = destination;
+            }
+            Account.SaveUnsignedTransaction proposal transactionMetadata filePath
+            Console.WriteLine("Transaction saved. Now copy it to the device with the private key.")
+            UserInteraction.PressAnyKeyToContinue()
+        | :? NormalAccount as normalAccount ->
+            TrySendAmount normalAccount transactionMetadata destination amount
+        | _ ->
+            failwith ("Account type not recognized: " + account.GetType().FullName)
+
+    let SendPayment() =
+        let account = UserInteraction.AskAccount()
+        let destination = UserInteraction.AskPublicAddress account.Currency "Destination address: "
+        let maybeAmount = UserInteraction.AskAmount account
+        match maybeAmount with
+        | None -> ()
+        | Some(amount) ->
+            let maybeFee = UserInteraction.AskFee account amount destination
+            match maybeFee with
+            | None -> ()
+            | Some(fee) ->
+                SendPaymentOfSpecificAmount account amount fee destination
+
+    let rec TryArchiveAccount account =
+        let password = UserInteraction.AskPassword(false)
+        try
+            Account.Archive account password
+            Console.WriteLine "Account archived."
+            UserInteraction.PressAnyKeyToContinue ()
+        with
+        | :? InvalidPassword ->
+            Presentation.Error "Invalid password, try again."
+            TryArchiveAccount account
+
+    let rec AddReadOnlyAccounts() =
+        Console.Write "JSON fragment from wallet to pair with: "
+        let watchWalletInfoJson = Console.ReadLine().Trim()
+        let watchWalletInfoOpt =
+            try
+                Marshalling.Deserialize watchWalletInfoJson
+                |> Some
+            with
+            | InvalidJson ->
+                None
+
+        match watchWalletInfoOpt with
+        | Some watchWalletInfo ->
+            Account.CreateReadOnlyAccounts watchWalletInfo
+            |> Some
+        | None ->
+            Console.WriteLine String.Empty
+            Presentation.Error
+                "The input provided didn't have proper JSON structure. Are you sure you gathered the info properly?"
+            Console.WriteLine (
+                sprintf
+                    "You have to choose the option '%s' in your offline device to obtain the JSON."
+                    (Presentation.ConvertPascalCaseToSentence (Operations.PairToWatchWallet.ToString()))
             )
             UserInteraction.PressAnyKeyToContinue()
-        else
-            let account = accounts.First()
-            if (accounts.Count() > 1) then
-                failwith "More than one normal account matching address and currency? Please report this issue."
-
-            match account with
-            | :? ReadOnlyAccount ->
-                failwith "Previous account filtering should have discarded readonly accounts already. Please report this issue"
-            | :? NormalAccount as normalAccount ->
-                Console.WriteLine ("Importing external data...")
-                Caching.Instance.SaveSnapshot unsignedTransaction.Cache
-
-                let lines = UserInteraction.DisplayAccountStatuses <| WhichAccount.MatchingWith account
-                               |> Async.RunSynchronously
-                Console.WriteLine ("Account to use when signing off this transaction:")
-                Console.WriteLine ()
-                for line in lines do
-                    Console.WriteLine line
-                Console.WriteLine()
-
-                Presentation.ShowTransactionData
-                    (unsignedTransaction.Proposal :> ITransactionDetails)
-                    unsignedTransaction.Metadata
-
-                if UserInteraction.AskYesNo "Do you accept?" then
-                    let trans = TrySign normalAccount unsignedTransaction
-                    Console.WriteLine("Transaction signed.")
-                    Console.Write("Introduce a file name or path to save it: ")
-                    let filePathToSaveTo = Console.ReadLine()
-                    Account.SaveSignedTransaction trans filePathToSaveTo
-                    Console.WriteLine("Transaction signed and saved successfully. Now copy it to the online device.")
-                    UserInteraction.PressAnyKeyToContinue ()
-            | _ ->
-                failwith "Account type not supported. Please report this issue."
-
-let TryConsumeJson func =
-    try
-        func()
-    with
-    | :? VersionMismatchDuringDeserializationException ->
-        Console.WriteLine()
-        Console.Error.WriteLine "There was an error (caused by a version mismatch) when trying to consume JSON;
-it is recommended to upgrade (both the hotwallet and the offline coldwallet)"
-        UserInteraction.PressAnyKeyToContinue()
-
-let SendPaymentOfSpecificAmount (account: IAccount)
-                                (amount: TransferAmount)
-                                (transactionMetadata: IBlockchainFeeInfo)
-                                (destination: string) =
-    match account with
-    | :? ReadOnlyAccount ->
-        Console.WriteLine("Cannot send payments from readonly accounts.")
-        Console.Write("Introduce a file name to save the unsigned transaction: ")
-        let filePath = Console.ReadLine()
-        let proposal = {
-            OriginMainAddress = account.PublicAddress;
-            Amount = amount;
-            DestinationAddress = destination;
-        }
-        Account.SaveUnsignedTransaction proposal transactionMetadata filePath
-        Console.WriteLine("Transaction saved. Now copy it to the device with the private key.")
-        UserInteraction.PressAnyKeyToContinue()
-    | :? NormalAccount as normalAccount ->
-        TrySendAmount normalAccount transactionMetadata destination amount
-    | _ ->
-        failwith ("Account type not recognized: " + account.GetType().FullName)
-
-let SendPayment() =
-    let account = UserInteraction.AskAccount()
-    let destination = UserInteraction.AskPublicAddress account.Currency "Destination address: "
-    let maybeAmount = UserInteraction.AskAmount account
-    match maybeAmount with
-    | None -> ()
-    | Some(amount) ->
-        let maybeFee = UserInteraction.AskFee account amount destination
-        match maybeFee with
-        | None -> ()
-        | Some(fee) ->
-            SendPaymentOfSpecificAmount account amount fee destination
-
-let rec TryArchiveAccount account =
-    let password = UserInteraction.AskPassword(false)
-    try
-        Account.Archive account password
-        Console.WriteLine "Account archived."
-        UserInteraction.PressAnyKeyToContinue ()
-    with
-    | :? InvalidPassword ->
-        Presentation.Error "Invalid password, try again."
-        TryArchiveAccount account
-
-let rec AddReadOnlyAccounts() =
-    Console.Write "JSON fragment from wallet to pair with: "
-    let watchWalletInfoJson = Console.ReadLine().Trim()
-    let watchWalletInfoOpt =
-        try
-            Marshalling.Deserialize watchWalletInfoJson
-            |> Some
-        with
-        | InvalidJson ->
             None
 
-    match watchWalletInfoOpt with
-    | Some watchWalletInfo ->
-        Account.CreateReadOnlyAccounts watchWalletInfo
-        |> Some
-    | None ->
-        Console.WriteLine String.Empty
-        Presentation.Error
-            "The input provided didn't have proper JSON structure. Are you sure you gathered the info properly?"
-        Console.WriteLine (
-            sprintf
-                "You have to choose the option '%s' in your offline device to obtain the JSON."
-                (Presentation.ConvertPascalCaseToSentence (Operations.PairToWatchWallet.ToString()))
-        )
-        UserInteraction.PressAnyKeyToContinue()
-        None
-
-let ArchiveAccount() =
-    let account = UserInteraction.AskAccount()
-    match account with
-    | :? ReadOnlyAccount as readOnlyAccount ->
-        Console.WriteLine("Read-only accounts cannot be archived, but just removed entirely.")
-        if not (UserInteraction.AskYesNo "Do you accept?") then
-            ()
-        else
-            Account.Remove readOnlyAccount
-            Console.WriteLine "Read-only account removed."
-            UserInteraction.PressAnyKeyToContinue()
-    | :? NormalAccount as normalAccount ->
-        let balance,_ =
-            Account.GetShowableBalanceAndImminentIncomingPayment account ServerSelectionMode.Fast None
-                |> Async.RunSynchronously
-        match balance with
-        | NotFresh(NotAvailable) ->
-            Presentation.Error "Removing accounts when offline is not supported."
-            ()
-        | Fresh(amount) | NotFresh(Cached(amount,_)) ->
-            if (amount > 0m) then
-                Presentation.Error "Please empty the account before removing it."
-                UserInteraction.PressAnyKeyToContinue ()
+    let ArchiveAccount() =
+        let account = UserInteraction.AskAccount()
+        match account with
+        | :? ReadOnlyAccount as readOnlyAccount ->
+            Console.WriteLine("Read-only accounts cannot be archived, but just removed entirely.")
+            if not (UserInteraction.AskYesNo "Do you accept?") then
+                ()
             else
-                Console.WriteLine ()
-                Console.WriteLine "Please note: "
-                Console.WriteLine "Just in case this account receives funds in the future by mistake, "
-                Console.WriteLine "the operation of archiving an account doesn't entirely remove it."
-                Console.WriteLine ()
-                Console.WriteLine "You will be asked the password of it now so that its private key can remain unencrypted in the configuration folder, in order for you to be able to safely forget this password."
-                Console.WriteLine "Then this account will be watched constantly and if new payments are detected, "
-                Console.WriteLine "GWallet will prompt you to move them to a current account without the need of typing the old password."
-                Console.WriteLine ()
-                if not (UserInteraction.AskYesNo "Do you accept?") then
-                    ()
+                Account.Remove readOnlyAccount
+                Console.WriteLine "Read-only account removed."
+                UserInteraction.PressAnyKeyToContinue()
+        | :? NormalAccount as normalAccount ->
+            let balance,_ =
+                Account.GetShowableBalanceAndImminentIncomingPayment account ServerSelectionMode.Fast None
+                    |> Async.RunSynchronously
+            match balance with
+            | NotFresh(NotAvailable) ->
+                Presentation.Error "Removing accounts when offline is not supported."
+                ()
+            | Fresh(amount) | NotFresh(Cached(amount,_)) ->
+                if (amount > 0m) then
+                    Presentation.Error "Please empty the account before removing it."
+                    UserInteraction.PressAnyKeyToContinue ()
                 else
-                    TryArchiveAccount normalAccount
-    | _ ->
-        failwithf "Account type not valid for archiving: %s. Please report this issue."
-                  (account.GetType().FullName)
+                    Console.WriteLine ()
+                    Console.WriteLine "Please note: "
+                    Console.WriteLine "Just in case this account receives funds in the future by mistake, "
+                    Console.WriteLine "the operation of archiving an account doesn't entirely remove it."
+                    Console.WriteLine ()
+                    Console.WriteLine "You will be asked the password of it now so that its private key can remain unencrypted in the configuration folder, in order for you to be able to safely forget this password."
+                    Console.WriteLine "Then this account will be watched constantly and if new payments are detected, "
+                    Console.WriteLine "GWallet will prompt you to move them to a current account without the need of typing the old password."
+                    Console.WriteLine ()
+                    if not (UserInteraction.AskYesNo "Do you accept?") then
+                        ()
+                    else
+                        TryArchiveAccount normalAccount
+        | _ ->
+            failwithf "Account type not valid for archiving: %s. Please report this issue."
+                      (account.GetType().FullName)
 
-let PairToWatchWallet() =
-    match Account.GetNormalAccountsPairingInfoForWatchWallet() with
-    | None ->
-        Presentation.Error
-            "There needs to be both Ether-based accounts and Utxo-based accounts to be able to use this feature."
-    | Some walletInfo ->
-        Console.WriteLine ""
-        Console.WriteLine "Copy/paste this JSON fragment in your watching wallet:"
-        Console.WriteLine ""
-        let json = Marshalling.SerializeOneLine walletInfo
-        Console.WriteLine json
-        Console.WriteLine ""
+    let PairToWatchWallet() =
+        match Account.GetNormalAccountsPairingInfoForWatchWallet() with
+        | None ->
+            Presentation.Error
+                "There needs to be both Ether-based accounts and Utxo-based accounts to be able to use this feature."
+        | Some walletInfo ->
+            Console.WriteLine ""
+            Console.WriteLine "Copy/paste this JSON fragment in your watching wallet:"
+            Console.WriteLine ""
+            let json = Marshalling.SerializeOneLine walletInfo
+            Console.WriteLine json
+            Console.WriteLine ""
 
-    UserInteraction.PressAnyKeyToContinue()
-
-type private GenericWalletOption =
-    | Cancel
-    | TestPaymentPassword
-    | TestSeedPassphrase
-    | WipeWallet
-
-let rec TestPaymentPassword () =
-    let password = UserInteraction.AskPassword false
-    if Account.CheckValidPassword password None |> Async.RunSynchronously |> not then
-        Console.WriteLine "Try again."
-        TestPaymentPassword ()
-
-let rec TestSeedPassphrase(): unit =
-    let passphrase,dob,email = UserInteraction.AskBrainSeed false
-    let check = Account.CheckValidSeed passphrase dob email |> Async.RunSynchronously
-    if not check then
-        Console.WriteLine "Try again."
-        TestSeedPassphrase()
-
-let WipeWallet() =
-    Console.WriteLine "If you want to remove accounts, the recommended way is to archive them, not wipe the whole wallet."
-    Console.Write "Are you ABSOLUTELY SURE about this? If yes, write 'YES' in uppercase: "
-    let sure = Console.ReadLine ()
-    if sure = "YES" then
-        Account.WipeAll()
-    else
-        ()
-
-let WalletOptions(): unit =
-    let rec AskWalletOption(): GenericWalletOption =
-        Console.WriteLine "0. Cancel, go back"
-        Console.WriteLine "1. Check you still remember your payment password"
-        Console.WriteLine "2. Check you still remember your secret recovery phrase"
-        Console.WriteLine "3. Wipe your current wallet, in order to start from scratch"
-        Console.Write "Choose an option from the ones above: "
-        let optIntroduced = Console.ReadLine ()
-        match UInt32.TryParse optIntroduced with
-        | false, _ -> AskWalletOption()
-        | true, optionParsed ->
-            match optionParsed with
-            | 0u -> GenericWalletOption.Cancel
-            | 1u -> GenericWalletOption.TestPaymentPassword
-            | 2u -> GenericWalletOption.TestSeedPassphrase
-            | 3u -> GenericWalletOption.WipeWallet
-            | _ -> AskWalletOption()
-
-    let walletOption = AskWalletOption()
-    match walletOption with
-    | GenericWalletOption.TestPaymentPassword ->
-        TestPaymentPassword()
-        Console.WriteLine "Success!"
-    | GenericWalletOption.TestSeedPassphrase ->
-        TestSeedPassphrase()
-        Console.WriteLine "Success!"
-    | GenericWalletOption.WipeWallet ->
-        WipeWallet()
-    | _ -> ()
-
-let rec PerformOperation (numActiveAccounts: uint32) (numHotAccounts: uint32) =
-    match UserInteraction.AskOperation numActiveAccounts numHotAccounts with
-    | Operations.Exit -> exit 0
-    | Operations.CreateAccounts ->
-        let bootstrapTask = Caching.Instance.BootstrapServerStatsFromTrustedSource() |> Async.StartAsTask
-        let passphrase,dob,email = UserInteraction.AskBrainSeed true
-        if not (isNull bootstrapTask.Exception) then
-            raise bootstrapTask.Exception
-        let masterPrivateKeyTask =
-            Account.GenerateMasterPrivateKey passphrase dob email
-                |> Async.StartAsTask
-        let password = UserInteraction.AskPassword true
-        Async.RunSynchronously <| async {
-            let! privateKeyBytes = Async.AwaitTask masterPrivateKeyTask
-            return! Account.CreateAllAccounts privateKeyBytes password
-        }
-        Console.WriteLine("Accounts created")
         UserInteraction.PressAnyKeyToContinue()
-    | Operations.Refresh -> ()
-    | Operations.SendPayment ->
-        SendPayment()
-    | Operations.AddReadonlyAccounts ->
-        match AddReadOnlyAccounts() with
-        | Some job ->
-            job
-            |> Async.RunSynchronously
-        | None -> ()
-    | Operations.SignOffPayment ->
-        TryConsumeJson SignOffPayment
-    | Operations.BroadcastPayment ->
-        TryConsumeJson BroadcastPayment
-    | Operations.ArchiveAccount ->
-        ArchiveAccount()
-    | Operations.PairToWatchWallet ->
-        PairToWatchWallet()
-    | Operations.Options ->
-        WalletOptions()
-    | _ -> failwith "Unreachable"
 
-let rec GetAccountOfSameCurrency currency =
-    let account = UserInteraction.AskAccount()
-    if (account.Currency <> currency) then
-        Presentation.Error (sprintf "The account selected doesn't match the currency %A" currency)
-        GetAccountOfSameCurrency currency
-    else
-        account
+    type private GenericWalletOption =
+        | Cancel
+        | TestPaymentPassword
+        | TestSeedPassphrase
+        | WipeWallet
 
-let rec CheckArchivedAccountsAreEmpty(): bool =
-    let archivedAccountsInNeedOfAction =
-        Account.GetArchivedAccountsWithPositiveBalance None
-            |> Async.RunSynchronously
-    for archivedAccount,balance in archivedAccountsInNeedOfAction do
-        let currency = (archivedAccount:>IAccount).Currency
-        Console.WriteLine (sprintf "ALERT! An archived account has received funds:%sAddress: %s Balance: %s%A"
-                               Environment.NewLine
-                               (archivedAccount:>IAccount).PublicAddress
-                               (balance.ToString())
-                               currency)
-        Console.WriteLine "Please indicate the account you would like to transfer the funds to."
-        let account = GetAccountOfSameCurrency currency
+    let rec TestPaymentPassword () =
+        let password = UserInteraction.AskPassword false
+        if Account.CheckValidPassword password None |> Async.RunSynchronously |> not then
+            Console.WriteLine "Try again."
+            TestPaymentPassword ()
 
-        let allBalance = TransferAmount(balance, balance, account.Currency)
-        let maybeFee = UserInteraction.AskFee archivedAccount allBalance account.PublicAddress
-        match maybeFee with
-        | None -> ()
-        | Some(feeInfo) ->
-            let sweepFunds ignoreHigherMinerFeeThanAmount =
-                let txId =
-                    Account.SweepArchivedFunds archivedAccount balance account feeInfo ignoreHigherMinerFeeThanAmount
-                        |> Async.RunSynchronously
-                Console.WriteLine(sprintf "Transaction successful, its ID is:%s%s" Environment.NewLine txId)
+    let rec TestSeedPassphrase(): unit =
+        let passphrase,dob,email = UserInteraction.AskBrainSeed false
+        let check = Account.CheckValidSeed passphrase dob email |> Async.RunSynchronously
+        if not check then
+            Console.WriteLine "Try again."
+            TestSeedPassphrase()
 
-            SendWithMinerFeeValidation sweepFunds
+    let WipeWallet() =
+        Console.WriteLine "If you want to remove accounts, the recommended way is to archive them, not wipe the whole wallet."
+        Console.Write "Are you ABSOLUTELY SURE about this? If yes, write 'YES' in uppercase: "
+        let sure = Console.ReadLine ()
+        if sure = "YES" then
+            Account.WipeAll()
+        else
+            ()
 
-    not (archivedAccountsInNeedOfAction.Any())
+    let WalletOptions(): unit =
+        let rec AskWalletOption(): GenericWalletOption =
+            Console.WriteLine "0. Cancel, go back"
+            Console.WriteLine "1. Check you still remember your payment password"
+            Console.WriteLine "2. Check you still remember your secret recovery phrase"
+            Console.WriteLine "3. Wipe your current wallet, in order to start from scratch"
+            Console.Write "Choose an option from the ones above: "
+            let optIntroduced = Console.ReadLine ()
+            match UInt32.TryParse optIntroduced with
+            | false, _ -> AskWalletOption()
+            | true, optionParsed ->
+                match optionParsed with
+                | 0u -> GenericWalletOption.Cancel
+                | 1u -> GenericWalletOption.TestPaymentPassword
+                | 2u -> GenericWalletOption.TestSeedPassphrase
+                | 3u -> GenericWalletOption.WipeWallet
+                | _ -> AskWalletOption()
 
+        let walletOption = AskWalletOption()
+        match walletOption with
+        | GenericWalletOption.TestPaymentPassword ->
+            TestPaymentPassword()
+            Console.WriteLine "Success!"
+        | GenericWalletOption.TestSeedPassphrase ->
+            TestSeedPassphrase()
+            Console.WriteLine "Success!"
+        | GenericWalletOption.WipeWallet ->
+            WipeWallet()
+        | _ -> ()
 
-let DateSanityCheck() =
-    let currentDate = DateTime.Now
-    match Caching.Instance.GetLastCachedData().GetLeastOldDate() with
-    | None -> ()
-    | Some date ->
-        if date > currentDate then
-            Console.Error.WriteLine(
-                sprintf "WARNING: detected current system date is %s, which suggests that either it's wrong or the cache data was generated in a moment with wrong future date(s) such as %s"
-                    (currentDate |> Formatting.ShowSaneDate)
-                    (date |> Formatting.ShowSaneDate)
-            )
-            Console.Error.Write "NOTE: it is recommended to fix this situation (by setting the current system date, or deleting the cache data folder), or the prices/rates might not update properly"
+    let rec PerformOperation (numActiveAccounts: uint32) (numHotAccounts: uint32) =
+        match UserInteraction.AskOperation numActiveAccounts numHotAccounts with
+        | Operations.Exit -> exit 0
+        | Operations.CreateAccounts ->
+            let bootstrapTask = Caching.Instance.BootstrapServerStatsFromTrustedSource() |> Async.StartAsTask
+            let passphrase,dob,email = UserInteraction.AskBrainSeed true
+            if not (isNull bootstrapTask.Exception) then
+                raise bootstrapTask.Exception
+            let masterPrivateKeyTask =
+                Account.GenerateMasterPrivateKey passphrase dob email
+                    |> Async.StartAsTask
+            let password = UserInteraction.AskPassword true
+            Async.RunSynchronously <| async {
+                let! privateKeyBytes = Async.AwaitTask masterPrivateKeyTask
+                return! Account.CreateAllAccounts privateKeyBytes password
+            }
+            Console.WriteLine("Accounts created")
             UserInteraction.PressAnyKeyToContinue()
+        | Operations.Refresh -> ()
+        | Operations.SendPayment ->
+            SendPayment()
+        | Operations.AddReadonlyAccounts ->
+            match AddReadOnlyAccounts() with
+            | Some job ->
+                job
+                |> Async.RunSynchronously
+            | None -> ()
+        | Operations.SignOffPayment ->
+            TryConsumeJson SignOffPayment
+        | Operations.BroadcastPayment ->
+            TryConsumeJson BroadcastPayment
+        | Operations.ArchiveAccount ->
+            ArchiveAccount()
+        | Operations.PairToWatchWallet ->
+            PairToWatchWallet()
+        | Operations.Options ->
+            WalletOptions()
+        | _ -> failwith "Unreachable"
 
-let rec ProgramMainLoop() =
-    let activeAccounts = Account.GetAllActiveAccounts()
-    let hotAccounts =
-        activeAccounts.Where(
-            fun acc ->
-                match acc with
-                | :? NormalAccount -> true
-                | _ -> false
-        )
+    let rec GetAccountOfSameCurrency currency =
+        let account = UserInteraction.AskAccount()
+        if (account.Currency <> currency) then
+            Presentation.Error (sprintf "The account selected doesn't match the currency %A" currency)
+            GetAccountOfSameCurrency currency
+        else
+            account
 
-    Console.WriteLine ()
-    Console.WriteLine "*** STATUS ***"
-    Console.WriteLine ()
+    let rec CheckArchivedAccountsAreEmpty(): bool =
+        let archivedAccountsInNeedOfAction =
+            Account.GetArchivedAccountsWithPositiveBalance None
+                |> Async.RunSynchronously
+        for archivedAccount,balance in archivedAccountsInNeedOfAction do
+            let currency = (archivedAccount:>IAccount).Currency
+            Console.WriteLine (sprintf "ALERT! An archived account has received funds:%sAddress: %s Balance: %s%A"
+                                   Environment.NewLine
+                                   (archivedAccount:>IAccount).PublicAddress
+                                   (balance.ToString())
+                                   currency)
+            Console.WriteLine "Please indicate the account you would like to transfer the funds to."
+            let account = GetAccountOfSameCurrency currency
 
-    let lines =
-        UserInteraction.DisplayAccountStatuses(WhichAccount.All activeAccounts)
-            |> Async.RunSynchronously
-    Console.WriteLine Environment.NewLine
-    Console.WriteLine (String.concat Environment.NewLine lines)
-    Console.WriteLine ()
+            let allBalance = TransferAmount(balance, balance, account.Currency)
+            let maybeFee = UserInteraction.AskFee archivedAccount allBalance account.PublicAddress
+            match maybeFee with
+            | None -> ()
+            | Some(feeInfo) ->
+                let sweepFunds ignoreHigherMinerFeeThanAmount =
+                    let txId =
+                        Account.SweepArchivedFunds archivedAccount balance account feeInfo ignoreHigherMinerFeeThanAmount
+                            |> Async.RunSynchronously
+                    Console.WriteLine(sprintf "Transaction successful, its ID is:%s%s" Environment.NewLine txId)
 
-    if CheckArchivedAccountsAreEmpty() then
-        PerformOperation (uint32 (activeAccounts.Count())) (uint32 (hotAccounts.Count()))
-    ProgramMainLoop()
+                SendWithMinerFeeValidation sweepFunds
 
-
-let NormalStartWithNoParameters () =
-
-    Infrastructure.SetupExceptionHook ()
-
-    let exitCode =
-        try
-            DateSanityCheck()
-
-            ProgramMainLoop ()
-            0
-        with
-        | ex ->
-            Infrastructure.LogOrReportCrash ex
-            1
-
-    exitCode
+        not (archivedAccountsInNeedOfAction.Any())
 
 
-let UpdateServersFile () =
-    ServerManager.UpdateServersFile()
-    0
+    let DateSanityCheck() =
+        let currentDate = DateTime.Now
+        match Caching.Instance.GetLastCachedData().GetLeastOldDate() with
+        | None -> ()
+        | Some date ->
+            if date > currentDate then
+                Console.Error.WriteLine(
+                    sprintf "WARNING: detected current system date is %s, which suggests that either it's wrong or the cache data was generated in a moment with wrong future date(s) such as %s"
+                        (currentDate |> Formatting.ShowSaneDate)
+                        (date |> Formatting.ShowSaneDate)
+                )
+                Console.Error.Write "NOTE: it is recommended to fix this situation (by setting the current system date, or deleting the cache data folder), or the prices/rates might not update properly"
+                UserInteraction.PressAnyKeyToContinue()
 
-let UpdateServersStats () =
-    ServerManager.UpdateServersStats()
-    0
+    let rec ProgramMainLoop() =
+        let activeAccounts = Account.GetAllActiveAccounts()
+        let hotAccounts =
+            activeAccounts.Where(
+                fun acc ->
+                    match acc with
+                    | :? NormalAccount -> true
+                    | _ -> false
+            )
 
-[<EntryPoint>]
-let main argv =
-    match argv.Length with
-    | 0 ->
-        NormalStartWithNoParameters()
-    | 1 when argv.[0] = "--version" ->
-        Console.WriteLine (sprintf "geewallet v%s" VersionHelper.CURRENT_VERSION)
+        Console.WriteLine ()
+        Console.WriteLine "*** STATUS ***"
+        Console.WriteLine ()
+
+        let lines =
+            UserInteraction.DisplayAccountStatuses(WhichAccount.All activeAccounts)
+                |> Async.RunSynchronously
+        Console.WriteLine Environment.NewLine
+        Console.WriteLine (String.concat Environment.NewLine lines)
+        Console.WriteLine ()
+
+        if CheckArchivedAccountsAreEmpty() then
+            PerformOperation (uint32 (activeAccounts.Count())) (uint32 (hotAccounts.Count()))
+        ProgramMainLoop()
+
+
+    let NormalStartWithNoParameters () =
+
+        Infrastructure.SetupExceptionHook ()
+
+        let exitCode =
+            try
+                DateSanityCheck()
+
+                ProgramMainLoop ()
+                0
+            with
+            | ex ->
+                Infrastructure.LogOrReportCrash ex
+                1
+
+        exitCode
+
+
+    let UpdateServersFile () =
+        ServerManager.UpdateServersFile()
         0
-    | 1 when argv.[0] = "--update-servers-file" ->
-        UpdateServersFile()
-    | 1 when argv.[0] = "--update-servers-stats" ->
-        UpdateServersStats()
-    | _ ->
-        failwith "Arguments not recognized"
+
+    let UpdateServersStats () =
+        ServerManager.UpdateServersStats()
+        0
+
+    [<EntryPoint>]
+    let main argv =
+        match argv.Length with
+        | 0 ->
+            NormalStartWithNoParameters()
+        | 1 when argv.[0] = "--version" ->
+            Console.WriteLine (sprintf "geewallet v%s" VersionHelper.CURRENT_VERSION)
+            0
+        | 1 when argv.[0] = "--update-servers-file" ->
+            UpdateServersFile()
+        | 1 when argv.[0] = "--update-servers-stats" ->
+            UpdateServersStats()
+        | _ ->
+            failwith "Arguments not recognized"

--- a/src/GWallet.Frontend.XF.Gtk/GWallet.Frontend.XF.Gtk.fsproj
+++ b/src/GWallet.Frontend.XF.Gtk/GWallet.Frontend.XF.Gtk.fsproj
@@ -230,6 +230,9 @@
     <Reference Condition="'$(TwoPhaseBuildDueToXBuildUsage)'=='true'" Include="GWallet.Frontend.XF">
       <HintPath>..\GWallet.Frontend.XF\bin\$(Configuration)\netstandard2.0\GWallet.Frontend.XF.dll</HintPath>
     </Reference>
+    <Reference Condition="'$(TwoPhaseBuildDueToXBuildUsage)'=='true'" Include="GWallet.Frontend.Console">
+      <HintPath>..\GWallet.Frontend.Console\bin\$(Configuration)\netstandard2.0\GWallet.Frontend.Console.dll</HintPath>
+    </Reference>
     <Reference Include="FSharpx.Collections">
       <HintPath>..\..\packages\FSharpx.Collections.3.1.0\lib\netstandard2.0\FSharpx.Collections.dll</HintPath>
     </Reference>
@@ -249,6 +252,10 @@
       <Link>logo.png</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <ProjectReference Condition="'$(TwoPhaseBuildDueToXBuildUsage)'!='true'" Include="..\GWallet.Frontend.Console\GWallet.Frontend.Console.fsproj">
+      <Project>{aed49e93-60c4-460e-9120-064a2e67dc28}</Project>
+      <Name>GWallet.Frontend.Console</Name>
+    </ProjectReference>
     <ProjectReference Condition="'$(TwoPhaseBuildDueToXBuildUsage)'!='true'" Include="..\GWallet.Frontend.XF\GWallet.Frontend.XF.fsproj">
       <Project>{85236682-6463-4209-B66C-E0643EF12B46}</Project>
       <Name>GWallet.Frontend.XF</Name>

--- a/src/GWallet.Frontend.XF.Gtk/Program.fs
+++ b/src/GWallet.Frontend.XF.Gtk/Program.fs
@@ -43,5 +43,7 @@ module Main =
         | 1 when argv.[0] = "--version" ->
             Console.WriteLine (SPrintF1 "geewallet v%s" VersionHelper.CURRENT_VERSION)
             0
+        | 1 when argv.[0] = "--console" ->
+            GWallet.Frontend.Console.Program.main Array.empty
         | _ ->
             failwith "Arguments not recognized"

--- a/src/gwallet.linux-legacy.sln
+++ b/src/gwallet.linux-legacy.sln
@@ -11,6 +11,8 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "GWallet.Backend.Legacy`", "
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "GWallet.Backend.Tests", "GWallet.Backend.Tests\GWallet.Backend.Tests-legacy.fsproj", "{F9448076-88BE-4045-8704-A652D133E036}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "GWallet.Frontend.Console", "GWallet.Frontend.Console\GWallet.Frontend.Console.fsproj", "{AED49E93-60C4-460E-9120-064A2E67DC28}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -37,5 +39,9 @@ Global
 		{F9448076-88BE-4045-8704-A652D133E036}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F9448076-88BE-4045-8704-A652D133E036}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F9448076-88BE-4045-8704-A652D133E036}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AED49E93-60C4-460E-9120-064A2E67DC28}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AED49E93-60C4-460E-9120-064A2E67DC28}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AED49E93-60C4-460E-9120-064A2E67DC28}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AED49E93-60C4-460E-9120-064A2E67DC28}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This commit allows for XF.GTK to open/call console version when passed the "--console" argument.

For Frontend.Console to be callable/referenceable from Frontend.XF.GTK, it needs to be built in .netstandard2.0 instead of net6.0, this commit does that. .NETStandard build happens when either a flag is passed (for stockdotnet6+stockmono lane) or when we're building on mono (for other lanes building XF.GTK).