### PR TITLE
Backend: upgrade JsonRpcSharp & Nethereum

### DIFF
--- a/src/GWallet.Backend/GWallet.Backend-legacy.fsproj
+++ b/src/GWallet.Backend/GWallet.Backend-legacy.fsproj
@@ -149,10 +149,10 @@
       <HintPath>..\..\packages\NBitcoin.6.0.17\lib\net461\NBitcoin.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions">
-      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.Pipelines">
-      <HintPath>..\..\packages\System.IO.Pipelines.4.5.3\lib\netstandard1.3\System.IO.Pipelines.dll</HintPath>
+      <HintPath>..\..\packages\System.IO.Pipelines.8.0.0\lib\net462\System.IO.Pipelines.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="FSharp.Core">
@@ -201,7 +201,7 @@
       <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.1.0.2\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="JsonRpcSharp.TcpClient">
-      <HintPath>..\..\packages\JsonRpcSharp.0.98.0--date20230731-1252.git-6788e32\lib\netstandard2.0\JsonRpcSharp.TcpClient.dll</HintPath>
+      <HintPath>..\..\packages\JsonRpcSharp.0.99.0--date20240303-0338.git-d673848\lib\netstandard2.0\JsonRpcSharp.TcpClient.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.Pipes">
       <HintPath>..\..\packages\System.IO.Pipes.4.3.0\lib\net46\System.IO.Pipes.dll</HintPath>
@@ -213,55 +213,55 @@
       <HintPath>..\..\packages\System.Net.WebSockets.Client.4.3.2\lib\net46\System.Net.WebSockets.Client.dll</HintPath>
     </Reference>
     <Reference Include="JsonRpcSharp.Client">
-      <HintPath>..\..\packages\JsonRpcSharp.0.98.0--date20230731-1252.git-6788e32\lib\netstandard2.0\JsonRpcSharp.Client.dll</HintPath>
+      <HintPath>..\..\packages\JsonRpcSharp.0.99.0--date20240303-0338.git-d673848\lib\netstandard2.0\JsonRpcSharp.Client.dll</HintPath>
     </Reference>
     <Reference Include="JsonRpcSharp.IpcClient">
-      <HintPath>..\..\packages\JsonRpcSharp.0.98.0--date20230731-1252.git-6788e32\lib\netstandard2.0\JsonRpcSharp.IpcClient.dll</HintPath>
+      <HintPath>..\..\packages\JsonRpcSharp.0.99.0--date20240303-0338.git-d673848\lib\netstandard2.0\JsonRpcSharp.IpcClient.dll</HintPath>
     </Reference>
     <Reference Include="JsonRpcSharp.HttpClient">
-      <HintPath>..\..\packages\JsonRpcSharp.0.98.0--date20230731-1252.git-6788e32\lib\netstandard2.0\JsonRpcSharp.HttpClient.dll</HintPath>
+      <HintPath>..\..\packages\JsonRpcSharp.0.99.0--date20240303-0338.git-d673848\lib\netstandard2.0\JsonRpcSharp.HttpClient.dll</HintPath>
     </Reference>
     <Reference Include="JsonRpcSharp.WebSocketClient">
-      <HintPath>..\..\packages\JsonRpcSharp.0.98.0--date20230731-1252.git-6788e32\lib\netstandard2.0\JsonRpcSharp.WebSocketClient.dll</HintPath>
+      <HintPath>..\..\packages\JsonRpcSharp.0.99.0--date20240303-0338.git-d673848\lib\netstandard2.0\JsonRpcSharp.WebSocketClient.dll</HintPath>
     </Reference>
     <Reference Include="Nethereum.ABI">
-      <HintPath>..\..\packages\Nethereum.0.95.0--date20210125-0551.git-05a29e9\lib\netstandard2.0\Nethereum.ABI.dll</HintPath>
+      <HintPath>..\..\packages\Nethereum.0.99.0--date20240303-0535.git-f0bc8be\lib\netstandard2.0\Nethereum.ABI.dll</HintPath>
     </Reference>
     <Reference Include="Nethereum.Accounts">
-      <HintPath>..\..\packages\Nethereum.0.95.0--date20210125-0551.git-05a29e9\lib\netstandard2.0\Nethereum.Accounts.dll</HintPath>
+      <HintPath>..\..\packages\Nethereum.0.99.0--date20240303-0535.git-f0bc8be\lib\netstandard2.0\Nethereum.Accounts.dll</HintPath>
     </Reference>
     <Reference Include="Nethereum.Contracts">
-      <HintPath>..\..\packages\Nethereum.0.95.0--date20210125-0551.git-05a29e9\lib\netstandard2.0\Nethereum.Contracts.dll</HintPath>
+      <HintPath>..\..\packages\Nethereum.0.99.0--date20240303-0535.git-f0bc8be\lib\netstandard2.0\Nethereum.Contracts.dll</HintPath>
     </Reference>
     <Reference Include="Nethereum.Hex">
-      <HintPath>..\..\packages\Nethereum.0.95.0--date20210125-0551.git-05a29e9\lib\netstandard2.0\Nethereum.Hex.dll</HintPath>
+      <HintPath>..\..\packages\Nethereum.0.99.0--date20240303-0535.git-f0bc8be\lib\netstandard2.0\Nethereum.Hex.dll</HintPath>
     </Reference>
     <Reference Include="Nethereum.KeyStore">
-      <HintPath>..\..\packages\Nethereum.0.95.0--date20210125-0551.git-05a29e9\lib\netstandard2.0\Nethereum.KeyStore.dll</HintPath>
+      <HintPath>..\..\packages\Nethereum.0.99.0--date20240303-0535.git-f0bc8be\lib\netstandard2.0\Nethereum.KeyStore.dll</HintPath>
     </Reference>
     <Reference Include="Nethereum.RLP">
-      <HintPath>..\..\packages\Nethereum.0.95.0--date20210125-0551.git-05a29e9\lib\netstandard2.0\Nethereum.RLP.dll</HintPath>
+      <HintPath>..\..\packages\Nethereum.0.99.0--date20240303-0535.git-f0bc8be\lib\netstandard2.0\Nethereum.RLP.dll</HintPath>
     </Reference>
     <Reference Include="Nethereum.RPC">
-      <HintPath>..\..\packages\Nethereum.0.95.0--date20210125-0551.git-05a29e9\lib\netstandard2.0\Nethereum.RPC.dll</HintPath>
+      <HintPath>..\..\packages\Nethereum.0.99.0--date20240303-0535.git-f0bc8be\lib\netstandard2.0\Nethereum.RPC.dll</HintPath>
     </Reference>
     <Reference Include="Nethereum.Signer">
-      <HintPath>..\..\packages\Nethereum.0.95.0--date20210125-0551.git-05a29e9\lib\netstandard2.0\Nethereum.Signer.dll</HintPath>
+      <HintPath>..\..\packages\Nethereum.0.99.0--date20240303-0535.git-f0bc8be\lib\netstandard2.0\Nethereum.Signer.dll</HintPath>
     </Reference>
     <Reference Include="Nethereum.StandardTokenEIP20">
-      <HintPath>..\..\packages\Nethereum.0.95.0--date20210125-0551.git-05a29e9\lib\netstandard2.0\Nethereum.StandardTokenEIP20.dll</HintPath>
+      <HintPath>..\..\packages\Nethereum.0.99.0--date20240303-0535.git-f0bc8be\lib\netstandard2.0\Nethereum.StandardTokenEIP20.dll</HintPath>
     </Reference>
     <Reference Include="Nethereum.Util">
-      <HintPath>..\..\packages\Nethereum.0.95.0--date20210125-0551.git-05a29e9\lib\netstandard2.0\Nethereum.Util.dll</HintPath>
+      <HintPath>..\..\packages\Nethereum.0.99.0--date20240303-0535.git-f0bc8be\lib\netstandard2.0\Nethereum.Util.dll</HintPath>
     </Reference>
     <Reference Include="Nethereum.Web3">
-      <HintPath>..\..\packages\Nethereum.0.95.0--date20210125-0551.git-05a29e9\lib\netstandard2.0\Nethereum.Web3.dll</HintPath>
+      <HintPath>..\..\packages\Nethereum.0.99.0--date20240303-0535.git-f0bc8be\lib\netstandard2.0\Nethereum.Web3.dll</HintPath>
     </Reference>
     <Reference Include="HtmlAgilityPack">
       <HintPath>..\..\packages\HtmlAgilityPack.1.11.24\lib\Net45\HtmlAgilityPack.dll</HintPath>
     </Reference>
     <Reference Include="System.Memory">
-      <HintPath>..\..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+      <HintPath>..\..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
     </Reference>
   </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/GWallet.Backend/GWallet.Backend.fsproj
+++ b/src/GWallet.Backend/GWallet.Backend.fsproj
@@ -68,7 +68,7 @@
     <PackageReference Include="NBitcoin.Altcoins" Version="3.0.8">
       <GeneratePathProperty></GeneratePathProperty>
     </PackageReference>
-    <PackageReference Include="Nethereum" Version="0.95.0--date20210125-0551.git-05a29e9">
+    <PackageReference Include="Nethereum" Version="0.99.0--date20240303-0535.git-f0bc8be">
       <GeneratePathProperty></GeneratePathProperty>
     </PackageReference>
     <PackageReference Include="SharpRaven" Version="2.4.0">
@@ -78,6 +78,9 @@
       <GeneratePathProperty></GeneratePathProperty>
     </PackageReference>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.24">
+      <GeneratePathProperty></GeneratePathProperty>
+    </PackageReference>
+    <PackageReference Include="JsonRpcSharp" Version="0.99.0--date20240303-0338.git-d673848">
       <GeneratePathProperty></GeneratePathProperty>
     </PackageReference>
   </ItemGroup>

--- a/src/GWallet.Backend/packages.config
+++ b/src/GWallet.Backend/packages.config
@@ -5,14 +5,14 @@
   <package id="FSharp.Core" version="4.7.0" targetFramework="net461" />
   <package id="FSharp.Data" version="3.0.0" targetFramework="net46" />
   <package id="HtmlAgilityPack" version="1.11.24" targetFramework="net471" />
-  <package id="JsonRpcSharp" version="0.98.0--date20230731-1252.git-6788e32" targetFramework="net461" />
+  <package id="JsonRpcSharp" version="0.99.0--date20240303-0338.git-d673848" targetFramework="net471" />
   <package id="Microsoft.CSharp" version="4.3.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="1.0.2" targetFramework="net46" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net46" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="NBitcoin" version="6.0.17" targetFramework="net471" />
   <package id="NBitcoin.Altcoins" version="3.0.8" targetFramework="net452" />
-  <package id="Nethereum" version="0.95.0--date20210125-0551.git-05a29e9" targetFramework="net461" />
+  <package id="Nethereum" version="0.99.0--date20240303-0535.git-f0bc8be" targetFramework="net471" />
   <package id="NETStandard.Library" version="2.0.3" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net46" />
   <package id="Portable.BouncyCastle" version="1.8.5.2" targetFramework="net461" />
@@ -32,11 +32,11 @@
   <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net46" />
   <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net46" />
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net46" />
-  <package id="System.IO.Pipelines" version="4.5.3" targetFramework="net46" />
+  <package id="System.IO.Pipelines" version="8.0.0" targetFramework="net471" />
   <package id="System.IO.Pipes" version="4.3.0" targetFramework="net46" />
   <package id="System.Linq" version="4.3.0" targetFramework="net46" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net46" />
-  <package id="System.Memory" version="4.5.4" targetFramework="net471" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net471" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="System.Net.Requests" version="4.3.0" targetFramework="net46" />
   <package id="System.Net.Sockets" version="4.3.0" targetFramework="net46" />
@@ -64,7 +64,7 @@
   <package id="System.Text.RegularExpressions" version="4.3.1" targetFramework="net46" />
   <package id="System.Threading" version="4.3.0" targetFramework="net46" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net46" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net46" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net471" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net46" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net46" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net46" />


### PR DESCRIPTION
The underlying reason to upgrade these dependencies was to actually upgrade their transitive dependencies (mainly the one called System.IO.Pipelines), with the hope that it might fix https://github.com/nblockchain/geewallet/issues/258 . In case it does not, we will create a new bug (hopefully with new stacktrace).

Closes https://github.com/nblockchain/geewallet/issues/258