### PR TITLE
Frontend.ConsoleApp: respect DRY in proj

### DIFF
--- a/src/GWallet.Frontend.ConsoleApp/GWallet.Frontend.ConsoleApp-legacy.fsproj
+++ b/src/GWallet.Frontend.ConsoleApp/GWallet.Frontend.ConsoleApp-legacy.fsproj
@@ -14,11 +14,6 @@
     <TargetFSharpCoreVersion>4.7.0.0</TargetFSharpCoreVersion>
     <Name>GWallet.Frontend.ConsoleApp</Name>
     <TargetFrameworkProfile />
-    <OtherFlags>
-        /warnon:1182
-        /warnon:3218
-        /warnon:0193
-    </OtherFlags>
     <BaseIntermediateOutputPath>obj\legacy\</BaseIntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -41,7 +36,6 @@
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DocumentationFile>bin\Release\GWallet.Frontend.ConsoleApp.XML</DocumentationFile>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>


### PR DESCRIPTION
These elements are already in src/CommonBuildProps-legacy.proj. This change is similar to [1] and should have been done in [2] (where this project was introduced).

[1] 1ab784130436634e3ee708326333d5ffaf9b4fc3
[2] https://github.com/nblockchain/geewallet/pull/262