### PR TITLE
Frontend.XF(WelcomePage): change layout to Grid

### DIFF
--- a/src/GWallet.Frontend.XF/WelcomePage.xaml
+++ b/src/GWallet.Frontend.XF/WelcomePage.xaml
@@ -3,17 +3,21 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:GWallet.Frontend.XF"
              x:Class="GWallet.Frontend.XF.WelcomePage">
-    <StackLayout x:Name="mainLayout"
+    <Grid x:Name="mainLayout"
+                 RowDefinitions="*,*,Auto,Auto,Auto,Auto,Auto"
                  VerticalOptions="Center"
                  Padding="20,20,20,20">
         <Label Text="Welcome to geewallet" x:Name="welcomeLabel"
                VerticalOptions="Center" HorizontalOptions="Center"
                FontSize="Large"
-               Margin="20,20,20,20"/>
+               Margin="20,20,20,20"
+               Grid.Row="0"
+            />
 
         <Grid
             x:Name="infoGrid"
             Padding="0,60,0,60"
+            Grid.Row="1"
             >
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="2*" />
@@ -40,12 +44,19 @@
 
         <Entry x:Name="passphraseEntry" IsPassword="true"
                Placeholder="Input your new secret recovery phrase"
-               TextChanged="OnPassphraseTextChanged" />
+               TextChanged="OnPassphraseTextChanged"
+               Grid.Row="2"
+            />
         <Entry x:Name="passphraseConfirmationEntry" IsPassword="true"
                Placeholder="Repeat your secret recovery phrase"
-               TextChanged="OnPassphraseTextChanged" />
+               TextChanged="OnPassphraseTextChanged"
+               Grid.Row="3"
+            />
 
-        <StackLayout Orientation="Horizontal">
+        <StackLayout
+            Orientation="Horizontal"
+            Grid.Row="4"
+            >
             <Label Text="Date of Birth (d/m/y):"
                    FontSize="Small"
                    HorizontalOptions="Start"
@@ -60,11 +71,15 @@
         <Entry x:Name="emailEntry" IsPassword="false"
                Placeholder="E-mail address"
                Keyboard="Email"
-               TextChanged="OnEmailTextChanged" />
+               TextChanged="OnEmailTextChanged"
+               Grid.Row="5"
+        />
 
         <Button x:Name="nextButton"
                 Text="Next" IsEnabled="false"
                 HorizontalOptions="Center"
-                Clicked="OnNextButtonClicked" />
-    </StackLayout>
+                Clicked="OnNextButtonClicked"
+                Grid.Row="6"
+        />
+    </Grid>
 </ContentPage>

--- a/src/GWallet.Frontend.XF/WelcomePage.xaml.fs
+++ b/src/GWallet.Frontend.XF/WelcomePage.xaml.fs
@@ -15,7 +15,7 @@ type WelcomePage(state: FrontendHelpers.IGlobalAppState) =
 
     let _ = base.LoadFromXaml(typeof<WelcomePage>)
 
-    let mainLayout = base.FindByName<StackLayout> "mainLayout"
+    let mainLayout = base.FindByName<Grid> "mainLayout"
     let infoGrid = mainLayout.FindByName<Grid> "infoGrid"
     let passphraseEntry = mainLayout.FindByName<Entry> "passphraseEntry"
     let passphraseConfirmationEntry = mainLayout.FindByName<Entry> "passphraseConfirmationEntry"


### PR DESCRIPTION
Use Grid instead of StackLayout so that our upcoming Maui app's layout is fixed. See [1] for more info.

This commit was extracted from the MAUI PR [2].

[1] https://github.com/dotnet/maui/wiki/Xamarin.Forms----MAUI.Controls-Layout-Differences#stacklayout
[2] https://github.com/nblockchain/geewallet/pull/241

Co-authored-by: webwarrior-ws `<reg@webwarrior.ws>`