### PR TITLE
Preparations before move to MAUI

### DIFF
--- a/src/GWallet.Frontend.XF/BalancesPage.xaml
+++ b/src/GWallet.Frontend.XF/BalancesPage.xaml
@@ -4,15 +4,23 @@
              xmlns:local="clr-namespace:GWallet.Frontend.XF"
              xmlns:controls="clr-namespace:GWallet.Frontend.XF.Controls"
              x:Class="GWallet.Frontend.XF.BalancesPage">
-    <StackLayout x:Name="mainLayout"
-                 Padding="0,0,0,0"
-                 VerticalOptions="FillAndExpand">
+    <Grid
+        x:Name="mainLayout"
+        Padding="0,0,0,0"
+        RowDefinitions="*,Auto,Auto"
+        RowSpacing="0"
+        VerticalOptions="FillAndExpand"
+    >
 
-        <StackLayout Orientation="Horizontal"
-                     Padding="15, 10"
-                     Spacing="30"
-                     VerticalOptions="FillAndExpand"
-                     HorizontalOptions="FillAndExpand">         
+        <FlexLayout 
+            Direction="Row"
+            JustifyContent="SpaceEvenly"
+            AlignItems="Center"
+            Margin="15, 10"
+            VerticalOptions="FillAndExpand"
+            HorizontalOptions="FillAndExpand"
+            Grid.Row="0"
+        >
 
             <!-- we add {V|H}Options=Center* not only to the Label, as a workaround to
             https://github.com/xamarin/Xamarin.Forms/issues/4655 -->
@@ -20,65 +28,67 @@
                    HasShadow="false"
                    BackgroundColor="Transparent"
                    BorderColor="Transparent"
-                   VerticalOptions="CenterAndExpand"
-                   HorizontalOptions="End"
+                   VerticalOptions="Center"
                    Padding="0"
-                   Margin="0,0,0,0">
-                <StackLayout x:Name="totalFiatAmountLayout"
-                             Orientation="Horizontal"
-                             VerticalOptions="CenterAndExpand"
-                             HorizontalOptions="Center"
-                             Margin="0,0,0,0">
-                    <Label Text="..." x:Name="totalFiatAmountLabel"
-                           VerticalOptions="CenterAndExpand"
-                           HorizontalOptions="Center"
+                   Margin="0,0,10,0"
+            >
+                <Label Text="..." x:Name="totalFiatAmountLabel"
                            Margin="0,0,0,0"
                            FontSize="22" />
-                </StackLayout>
             </Frame>
 
-            <!-- keep this frame&stacklayout&label below almost same as previous! -->
+            <!-- keep this frame&label below almost same as previous! -->
             <Frame x:Name="totalReadOnlyFiatAmountFrame"
                    HasShadow="false"
                    IsVisible="false"
                    BackgroundColor="Transparent"
                    BorderColor="Transparent"
-                   VerticalOptions="CenterAndExpand"
-                   HorizontalOptions="End"
+                   VerticalOptions="Center"
                    Padding="0"
-                   Margin="0,0,0,0">
-                <StackLayout x:Name="totalReadOnlyFiatAmountLayout"
-                             Orientation="Horizontal"
-                             VerticalOptions="CenterAndExpand"
-                             HorizontalOptions="Center"
-                             Margin="0,0,0,0">
-                    <Label Text="..." x:Name="totalReadOnlyFiatAmountLabel"
-                           VerticalOptions="CenterAndExpand"
-                           HorizontalOptions="Center"
+                   Margin="0,0,10,0"
+            >
+                <Label Text="..." x:Name="totalReadOnlyFiatAmountLabel"
                            Margin="0,0,0,0"
                            FontSize="22"
                            TextColor="DarkBlue" />
-                </StackLayout>
             </Frame>
 
             <controls:CircleChartView x:Name="normalChartView"
                                      HorizontalOptions="FillAndExpand"
-                                     VerticalOptions="FillAndExpand"/>
-            
+                                     VerticalOptions="FillAndExpand"
+                                     FlexLayout.Grow="1.0"
+                                     FlexLayout.AlignSelf="Stretch"
+            />
+
             <controls:CircleChartView x:Name="readonlyChartView"
                                      IsVisible="False"
                                      HorizontalOptions="FillAndExpand"
-                                     VerticalOptions="FillAndExpand"/>
+                                     VerticalOptions="FillAndExpand"
+                                     FlexLayout.Grow="1.0"
+                                     FlexLayout.AlignSelf="Stretch"/>
 
-        </StackLayout>
+        </FlexLayout>
 
-        <ScrollView HorizontalOptions="FillAndExpand">
-            <StackLayout x:Name="contentLayout" />
+        <ScrollView
+            HorizontalOptions="FillAndExpand"
+            Grid.Row="1"
+        >
+            <Grid x:Name="contentLayout" />
         </ScrollView>
 
-        <Label Text="www.geewallet.com" x:Name="footerLabel"
+        <Frame x:Name="footerLabelFrame"
+               Grid.Row="2"
                VerticalOptions="End"
                HorizontalOptions="Center"
-               Margin="0,10,0,10" />
-    </StackLayout>
+               BorderColor="Transparent"
+               BackgroundColor="Transparent"
+               Margin="0"
+               Padding="0"
+        >
+            <Label
+                x:Name="footerLabel"
+                Text="www.geewallet.com"
+            />
+        </Frame>
+    </Grid>
 </ContentPage>

--- a/src/GWallet.Frontend.XF/Controls/CircleChartView.fs
+++ b/src/GWallet.Frontend.XF/Controls/CircleChartView.fs
@@ -144,14 +144,15 @@ type CircleChartView () =
        ()         
 
     member private self.CreateAndSetImageSource (imageSource : ImageSource) =
-        let image =
-            Image (
-                HorizontalOptions = LayoutOptions.FillAndExpand,
-                VerticalOptions = LayoutOptions.FillAndExpand,
-                Aspect = Aspect.AspectFit,
-                Source = imageSource
-            )
-        self.Content <- image
+        if not (self.Content :? Image) then
+            let image =
+                Image (
+                    HorizontalOptions = LayoutOptions.FillAndExpand,
+                    VerticalOptions = LayoutOptions.FillAndExpand,
+                    Aspect = Aspect.AspectFit,
+                    Source = imageSource
+                )
+            self.Content <- image
 
     member self.Draw () =
         let width = 

--- a/src/GWallet.Frontend.XF/LoadingPage.xaml
+++ b/src/GWallet.Frontend.XF/LoadingPage.xaml
@@ -3,7 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:GWallet.Frontend.XF"
              x:Class="GWallet.Frontend.XF.LoadingPage">
-    <StackLayout x:Name="mainLayout"
+    <Grid x:Name="mainLayout"
+                 RowDefinitions="*,Auto,*"
                  Padding="20,150,20,50"
                  VerticalOptions="Start">
 
@@ -12,7 +13,9 @@
                HorizontalOptions="Center"
                IsVisible="false"
                Margin="40,40,40,40"
-               FontAttributes="Bold" FontSize="Large" />
+               FontAttributes="Bold" FontSize="Large"
+               Grid.Row="0"
+        />
 
         <StackLayout
             IsVisible="false"
@@ -20,6 +23,7 @@
             Orientation="Horizontal"
             Spacing="0,0,0,0"
             HeightRequest="10"
+            Grid.Row="1"
             >
             <Frame BackgroundColor="Transparent"
                    BorderColor="Gray"
@@ -46,6 +50,8 @@
                VerticalOptions="End"
                HorizontalOptions="Center"
                IsVisible="false"
-               Margin="40,40,40,40" />
-    </StackLayout>
+               Margin="40,40,40,40"
+               Grid.Row="2"
+        />
+    </Grid>
 </ContentPage>

--- a/src/GWallet.Frontend.XF/LoadingPage.xaml.fs
+++ b/src/GWallet.Frontend.XF/LoadingPage.xaml.fs
@@ -19,7 +19,7 @@ type LoadingPage(state: FrontendHelpers.IGlobalAppState, showLogoFirst: bool) as
 
     let _ = base.LoadFromXaml(typeof<LoadingPage>)
 
-    let mainLayout = base.FindByName<StackLayout> "mainLayout"
+    let mainLayout = base.FindByName<Grid> "mainLayout"
     let titleLabel = mainLayout.FindByName<Label> "titleLabel"
     let progressBarLayout = base.FindByName<StackLayout> "progressBarLayout"
     let loadingLabel = mainLayout.FindByName<Label> "loadingLabel"

--- a/src/GWallet.Frontend.XF/PairingFromPage.xaml
+++ b/src/GWallet.Frontend.XF/PairingFromPage.xaml
@@ -32,17 +32,12 @@
                      VerticalOptions="CenterAndExpand"
                      >
             <zx:ZXingBarcodeImageView x:Name="qrCode"
-                                      BarcodeFormat="QR_CODE"
                                       HorizontalOptions="Start"
                                       VerticalOptions="Start"
                                       IsVisible="false"
                                       WidthRequest="400"
                                       HeightRequest="400"
                                       >
-                <zx:ZXingBarcodeImageView.BarcodeOptions>
-                    <zxcm:EncodingOptions Width="400"
-                                          Height="400" />
-                </zx:ZXingBarcodeImageView.BarcodeOptions>
             </zx:ZXingBarcodeImageView>
         </StackLayout>
         <StackLayout Padding="0,0,0,0"

--- a/src/GWallet.Frontend.XF/PairingFromPage.xaml.fs
+++ b/src/GWallet.Frontend.XF/PairingFromPage.xaml.fs
@@ -33,6 +33,8 @@ type PairingFromPage(previousPage: Page,
             failwith "Couldn't find QR code"
         qrCode.BarcodeValue <- qrCodeContents
         qrCode.IsVisible <- true
+        qrCode.BarcodeFormat <- ZXing.BarcodeFormat.QR_CODE
+        qrCode.BarcodeOptions <- ZXing.Common.EncodingOptions(Width = 400, Height = 400)
 
         let nextStepButton = mainLayout.FindByName<Button> "nextStepButton"
         match nextButtonCaptionAndSendPage with

--- a/src/GWallet.Frontend.XF/PairingToPage.xaml
+++ b/src/GWallet.Frontend.XF/PairingToPage.xaml
@@ -2,12 +2,14 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="GWallet.Frontend.XF.PairingToPage">
-    <StackLayout x:Name="mainLayout"
+    <Grid x:Name="mainLayout"
+                 RowDefinitions="*,*,*,*"
                  Padding="10,10,10,10"
                  VerticalOptions="Center"
                  HorizontalOptions="FillAndExpand">
         <StackLayout Orientation="Horizontal"
                      HorizontalOptions="FillAndExpand"
+                     Grid.Row="0"
                      >
             <Label Text="Cold storage addresses:"
                    HorizontalOptions="Start"
@@ -34,17 +36,22 @@
                TextChanged="OnEntryTextChanged"
                IsSpellCheckEnabled="false"
                IsTextPredictionEnabled="false"
+               Grid.Row="1"
                 />
 
         <Button x:Name="pairButton"
                 Text="Pair"
                 IsEnabled="false"
                 HorizontalOptions="Center"
-                Clicked="OnPairButtonClicked"/>
+                Clicked="OnPairButtonClicked"
+                Grid.Row="2"
+        />
         <Button x:Name="cancelButton"
                 Text="Cancel"
                 IsEnabled="true"
                 HorizontalOptions="Center"
-                Clicked="OnCancelButtonClicked"/>
-    </StackLayout>
+                Clicked="OnCancelButtonClicked"
+                Grid.Row="3"
+        />
+    </Grid>
 </ContentPage>

--- a/src/GWallet.Frontend.XF/PairingToPage.xaml.fs
+++ b/src/GWallet.Frontend.XF/PairingToPage.xaml.fs
@@ -18,7 +18,7 @@ type PairingToPage(balancesPage: Page,
     inherit ContentPage()
     let _ = base.LoadFromXaml(typeof<PairingToPage>)
 
-    let mainLayout = base.FindByName<StackLayout>("mainLayout")
+    let mainLayout = base.FindByName<Grid> "mainLayout"
     let scanQrCodeButton = mainLayout.FindByName<Button>("scanQrCode")
     let coldAddressesEntry = mainLayout.FindByName<Entry>("coldStorageAddresses")
     let pairButton = mainLayout.FindByName<Button>("pairButton")

--- a/src/GWallet.Frontend.XF/ReceivePage.xaml
+++ b/src/GWallet.Frontend.XF/ReceivePage.xaml
@@ -4,29 +4,40 @@
              x:Class="GWallet.Frontend.XF.ReceivePage"
              xmlns:zx="clr-namespace:ZXing.Net.Mobile.Forms;assembly=ZXing.Net.Mobile.Forms"
              xmlns:zxcm="clr-namespace:ZXing.Common;assembly=zxing">
-    <StackLayout x:Name="mainLayout"
-                 Padding="10,10,10,10"
-                 VerticalOptions="Center">
+    <Grid x:Name="mainLayout"
+          RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto"
+          Padding="10,10,10,10"
+          VerticalOptions="Center"
+    >
         <Label x:Name="balanceLabel"
                Text="..."
-               HorizontalOptions="Center" />
+               HorizontalOptions="Center"
+               Grid.Row="0"
+        />
         <Image
             x:Name="currencyImage"
             IsVisible="false"
-            />
+            Grid.Row="1"
+        />
         <Label x:Name="fiatBalanceLabel"
                Text="..."
-               HorizontalOptions="Center" />
+               HorizontalOptions="Center"
+               Grid.Row="2"
+        />
         <Button x:Name="paymentButton"
                 Text="..."
                 IsEnabled="false"
                 HorizontalOptions="Center"
-                Clicked="OnSendPaymentClicked"/>
+                Clicked="OnSendPaymentClicked"
+                Grid.Row="3"
+        />
         <Button x:Name="copyToClipboardButton"
                 Text="Copy address to clipboard"
                 IsEnabled="true"
                 HorizontalOptions="Center"
-                Clicked="OnCopyToClipboardClicked"/>
+                Clicked="OnCopyToClipboardClicked"
+                Grid.Row="4"
+        />
         <zx:ZXingBarcodeImageView
             x:Name="qrCode"
             BarcodeFormat="QR_CODE"
@@ -35,6 +46,7 @@
             IsVisible="false"
             WidthRequest="200"
             HeightRequest="200"
+            Grid.Row="5"
             >
             <zx:ZXingBarcodeImageView.BarcodeOptions>
                 <zxcm:EncodingOptions
@@ -42,6 +54,7 @@
                     Height="200"
                     />
             </zx:ZXingBarcodeImageView.BarcodeOptions>
+
         </zx:ZXingBarcodeImageView>
         <Button
             x:Name="viewTransactionHistoryButton"
@@ -49,6 +62,7 @@
             IsEnabled="true"
             HorizontalOptions="Center"
             Clicked="OnViewTransactionHistoryClicked"
+            Grid.Row="6"
             />
-    </StackLayout>
+    </Grid>
 </ContentPage>

--- a/src/GWallet.Frontend.XF/ReceivePage.xaml
+++ b/src/GWallet.Frontend.XF/ReceivePage.xaml
@@ -40,7 +40,6 @@
         />
         <zx:ZXingBarcodeImageView
             x:Name="qrCode"
-            BarcodeFormat="QR_CODE"
             HorizontalOptions="Center"
             VerticalOptions="Center"
             IsVisible="false"
@@ -48,13 +47,6 @@
             HeightRequest="200"
             Grid.Row="5"
             >
-            <zx:ZXingBarcodeImageView.BarcodeOptions>
-                <zxcm:EncodingOptions
-                    Width="200"
-                    Height="200"
-                    />
-            </zx:ZXingBarcodeImageView.BarcodeOptions>
-
         </zx:ZXingBarcodeImageView>
         <Button
             x:Name="viewTransactionHistoryButton"

--- a/src/GWallet.Frontend.XF/ReceivePage.xaml.fs
+++ b/src/GWallet.Frontend.XF/ReceivePage.xaml.fs
@@ -22,7 +22,7 @@ type ReceivePage(account: IAccount,
     inherit ContentPage()
     let _ = base.LoadFromXaml(typeof<ReceivePage>)
 
-    let mainLayout = base.FindByName<StackLayout>("mainLayout")
+    let mainLayout = base.FindByName<Grid> "mainLayout"
     let paymentButton = mainLayout.FindByName<Button> "paymentButton"
     let transactionHistoryButton =
         mainLayout.FindByName<Button> "viewTransactionHistoryButton"

--- a/src/GWallet.Frontend.XF/ReceivePage.xaml.fs
+++ b/src/GWallet.Frontend.XF/ReceivePage.xaml.fs
@@ -104,6 +104,8 @@ type ReceivePage(account: IAccount,
             failwith "Couldn't find QR code"
         qrCode.BarcodeValue <- account.PublicAddress
         qrCode.IsVisible <- true
+        qrCode.BarcodeFormat <- ZXing.BarcodeFormat.QR_CODE
+        qrCode.BarcodeOptions <- ZXing.Common.EncodingOptions(Width = 200, Height = 200)
 
         let currentConnectivityInstance = Connectivity.NetworkAccess
         if currentConnectivityInstance = NetworkAccess.Internet then

--- a/src/GWallet.Frontend.XF/SendPage.xaml
+++ b/src/GWallet.Frontend.XF/SendPage.xaml
@@ -2,14 +2,19 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="GWallet.Frontend.XF.SendPage">
-    <StackLayout x:Name="mainLayout"
-                 Padding="10,10,10,10"
-                 VerticalOptions="Center"
-                 HorizontalOptions="FillAndExpand">
+    <Grid x:Name="mainLayout"
+          Padding="10,10,10,10"
+          VerticalOptions="Center"
+          HorizontalOptions="FillAndExpand"
+          RowSpacing="0"
+          RowDefinitions="Auto,Auto,*,Auto,*,Auto,*,Auto,Auto"
+    >
         <StackLayout x:Name="transactionLayout"
                      Orientation="Horizontal"
                      HorizontalOptions="FillAndExpand"
-                     IsVisible="false">
+                     IsVisible="false"
+                     Grid.Row="0"
+        >
             <Label x:Name="transactionLabel"
                    Text="Transaction proposal:"
                    HorizontalOptions="Start"
@@ -35,10 +40,12 @@
         <Entry x:Name="transactionEntry"
                TextChanged="OnTransactionEntryTextChanged"
                IsVisible="false"
+               Grid.Row="1"
                />
 
         <StackLayout Orientation="Horizontal"
                      HorizontalOptions="FillAndExpand"
+                     Grid.Row="2"
                      >
             <Label Text="Destination address:"
                    HorizontalOptions="Start"
@@ -65,24 +72,35 @@
                TextChanged="OnEntryTextChanged"
                IsSpellCheckEnabled="false"
                IsTextPredictionEnabled="false"
+               Grid.Row="3"
                 />
 
-        <StackLayout Orientation="Horizontal"
-                     HorizontalOptions="FillAndExpand"
-                     Padding="0,10,0,0">
+        <Grid ColumnDefinitions="Auto,*,Auto"
+                    HorizontalOptions="FillAndExpand"
+                    Padding="0,10,0,0"
+                    Grid.Row="4"
+        >
             <Label Text="Amount:"
                    HorizontalOptions="Start"
-                   VerticalOptions="End" />
+                   VerticalOptions="Center"
+                   Grid.Column="0"
+            />
             <Label x:Name="equivalentAmountInAlternativeCurrency"
                    Text=""
                    FontAttributes="Italic" FontSize="Small"
-                   HorizontalOptions="Center"
-                   VerticalOptions="End" />
+                   HorizontalOptions="Start"
+                   HorizontalTextAlignment="Start"
+                   LineBreakMode="TailTruncation"
+                   VerticalOptions="Center"
+                   Grid.Column="1"
+            />
             <Button x:Name="allBalance"
                     Text="All balance"
                     HorizontalOptions="EndAndExpand"
-                    VerticalOptions="End"
-                    Clicked="OnAllBalanceButtonClicked">
+                    VerticalOptions="Center"
+                    Clicked="OnAllBalanceButtonClicked"
+                    Grid.Column="2"
+            >
                 <Button.HeightRequest>
                     <OnPlatform x:TypeArguments="x:Double">
                         <On Platform="iOS">15</On>
@@ -91,11 +109,14 @@
                     </OnPlatform>
                 </Button.HeightRequest>
             </Button>
-        </StackLayout>
+        </Grid>
 
-        <Grid HorizontalOptions="FillAndExpand">
+        <Grid x:Name="amountToSendLayout"
+              HorizontalOptions="FillAndExpand"
+              Grid.Row="5"
+        >
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
                 <!-- This is a workaround to upstream bug https://github.com/xamarin/Xamarin.Forms/issues/14977 -->
                 <ColumnDefinition Width="6*"/>
             </Grid.ColumnDefinitions>
@@ -113,23 +134,36 @@
                    TextChanged="OnEntryTextChanged" />
 
         </Grid>
-
-        <Label Text="Password:"
-               x:Name="passwordLabel"
-               />
-        <Entry x:Name="passwordEntry"
-               IsPassword="true"
-               TextChanged="OnEntryTextChanged" />
+        <Grid
+            RowDefinitions="*,Auto"
+            Grid.Row="6"
+        >
+            <Label
+                x:Name="passwordLabel"
+                Text="Password:"
+                Grid.Row="0"
+            />
+            <Entry
+                x:Name="passwordEntry"
+                IsPassword="true"
+                TextChanged="OnEntryTextChanged"
+                Grid.Row="1"
+            />
+        </Grid>
 
         <Button x:Name="sendOrSignButton"
                 Text="..."
                 IsEnabled="false"
                 HorizontalOptions="Center"
-                Clicked="OnSendOrSignButtonClicked"/>
+                Clicked="OnSendOrSignButtonClicked"
+                Grid.Row="7"
+        />
         <Button x:Name="cancelButton"
                 Text="Cancel"
                 IsEnabled="true"
                 HorizontalOptions="Center"
-                Clicked="OnCancelButtonClicked"/>
-    </StackLayout>
+                Clicked="OnCancelButtonClicked"
+                Grid.Row="8"
+        />
+    </Grid>
 </ContentPage>

--- a/src/GWallet.Frontend.XF/SendPage.xaml.fs
+++ b/src/GWallet.Frontend.XF/SendPage.xaml.fs
@@ -50,7 +50,7 @@ type SendPage(account: IAccount, receivePage: Page, newReceivePageFunc: unit->Pa
     // TODO: this means MinerFeeHigherThanOutputs exception could be thrown (so, crash), handle it
     let ignoreMinerFeeHigherThanOutputs = false
 
-    let mainLayout = base.FindByName<StackLayout>("mainLayout")
+    let mainLayout = base.FindByName<Grid> "mainLayout"
     let destinationScanQrCodeButton = mainLayout.FindByName<Button> "destinationScanQrCodeButton"
     let transactionScanQrCodeButton = mainLayout.FindByName<Button> "transactionScanQrCodeButton"
     let currencySelectorPicker = mainLayout.FindByName<Picker>("currencySelector")
@@ -102,6 +102,16 @@ type SendPage(account: IAccount, receivePage: Page, newReceivePageFunc: unit->Pa
                 (self :> FrontendHelpers.IAugmentablePayPage).AddTransactionScanner()
             self.AdjustWidgetsStateAccordingToConnectivity()
 
+        if Device.RuntimePlatform = Device.GTK then
+
+            // workaround bug on Xamarin.Forms/GTK about currency selection
+            // combo disappearing when resizing application main window
+            let amountToSendLayout = mainLayout.FindByName<Grid> "amountToSendLayout"
+            amountToSendLayout.ColumnDefinitions.[0] <- ColumnDefinition()
+
+            // workaround so that controls are not lumped together on GTK
+            mainLayout.RowSpacing <- 5.0
+
     [<Obsolete(DummyPageConstructorHelper.Warning)>]
     new() = SendPage(ReadOnlyAccount(Currency.BTC, { Name = "dummy"; Content = fun _ -> "" }, fun _ -> ""),
                      DummyPageConstructorHelper.PageFuncToRaiseExceptionIfUsedAtRuntime(),(fun _ -> Page()))
@@ -116,7 +126,7 @@ type SendPage(account: IAccount, receivePage: Page, newReceivePageFunc: unit->Pa
             )
 
     member self.OnTransactionScanQrCodeButtonClicked(_sender: Object, _args: EventArgs): unit =
-        let mainLayout = base.FindByName<StackLayout> "mainLayout"
+        let mainLayout = base.FindByName<Grid> "mainLayout"
         let transactionEntry = mainLayout.FindByName<Entry> "transactionEntry"
 
         let scanPage = ZXingScannerPage FrontendHelpers.BarCodeScanningOptions
@@ -138,7 +148,7 @@ type SendPage(account: IAccount, receivePage: Page, newReceivePageFunc: unit->Pa
         )
 
     member self.OnScanQrCodeButtonClicked(_sender: Object, _args: EventArgs): unit =
-        let mainLayout = base.FindByName<StackLayout>("mainLayout")
+        let mainLayout = base.FindByName<Grid> "mainLayout"
 
         let scanPage = ZXingScannerPage FrontendHelpers.BarCodeScanningOptions
         scanPage.add_OnScanResult(fun result ->
@@ -391,7 +401,7 @@ type SendPage(account: IAccount, receivePage: Page, newReceivePageFunc: unit->Pa
                 String.IsNullOrEmpty passwordEntry.Text
 
     member self.OnTransactionEntryTextChanged (_sender: Object, _args: EventArgs): unit =
-        let mainLayout = base.FindByName<StackLayout> "mainLayout"
+        let mainLayout = base.FindByName<Grid> "mainLayout"
         let transactionEntry = mainLayout.FindByName<Entry> "transactionEntry"
         let transactionEntryText = transactionEntry.Text
         if not (String.IsNullOrWhiteSpace transactionEntryText) then
@@ -532,7 +542,7 @@ type SendPage(account: IAccount, receivePage: Page, newReceivePageFunc: unit->Pa
                 }
 
     member self.OnEntryTextChanged(_sender: Object, _args: EventArgs) =
-        let mainLayout = base.FindByName<StackLayout>("mainLayout")
+        let mainLayout = base.FindByName<Grid> "mainLayout"
         if isNull mainLayout then
             //page not yet ready
             ()

--- a/src/GWallet.Frontend.XF/WelcomePage2.xaml
+++ b/src/GWallet.Frontend.XF/WelcomePage2.xaml
@@ -3,23 +3,33 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:GWallet.Frontend.XF"
              x:Class="GWallet.Frontend.XF.WelcomePage2">
-    <StackLayout x:Name="mainLayout"
+    <Grid x:Name="mainLayout"
                  VerticalOptions="Center"
-                 Padding="20,20,20,20">
+                 Padding="20,20,20,20"
+                 RowDefinitions="*,Auto,Auto,Auto"
+    >
         <Label Text="Now create a payment-password:" x:Name="nowLabel"
                VerticalOptions="Center" HorizontalOptions="Center"
-               Margin="20,20,20,20"/>
+               Margin="20,20,20,20"
+               Grid.Row="0"
+        />
 
         <Entry x:Name="passwordEntry" IsPassword="true"
                Placeholder="Input your new payment password"
-               TextChanged="OnPasswordTextChanged" />
+               TextChanged="OnPasswordTextChanged"
+               Grid.Row="1"
+        />
         <Entry x:Name="passwordEntryConfirmation" IsPassword="true"
                Placeholder="Repeat your payment password"
-               TextChanged="OnPasswordTextChanged" />
+               TextChanged="OnPasswordTextChanged"
+               Grid.Row="2"
+        />
 
         <Button x:Name="finishButton"
                 Text="Finish" IsEnabled="false"
                 HorizontalOptions="Center"
-                Clicked="OnFinishButtonClicked" />
-    </StackLayout>
+                Clicked="OnFinishButtonClicked"
+                Grid.Row="3"
+        />
+    </Grid>
 </ContentPage>

--- a/src/GWallet.Frontend.XF/WelcomePage2.xaml.fs
+++ b/src/GWallet.Frontend.XF/WelcomePage2.xaml.fs
@@ -14,7 +14,7 @@ type WelcomePage2(state: FrontendHelpers.IGlobalAppState, masterPrivateKeyGenera
 
     let _ = base.LoadFromXaml(typeof<WelcomePage2>)
 
-    let mainLayout = base.FindByName<StackLayout> "mainLayout"
+    let mainLayout = base.FindByName<Grid> "mainLayout"
 
     let password = mainLayout.FindByName<Entry> "passwordEntry"
     let passwordConfirmation = mainLayout.FindByName<Entry> "passwordEntryConfirmation"


### PR DESCRIPTION
1. Use Grid instead of StackLayout as root layout so that in Maui the layout is the same as in Xamarin.Forms (was not true with StackLayout).
2. Remove ZXingBarcodeImageView.BarcodeOptions from xaml files as MAUI version of ZXing library doesn't support this tag in xaml anymore.