### PR TITLE
scripts,Backend,Frontend.*: DRY for app name

### DIFF
--- a/scripts/bump.fsx
+++ b/scripts/bump.fsx
@@ -239,7 +239,7 @@ let RunUpdateServers () =
     match proc.Result with
     | Error _ ->
         Console.WriteLine()
-        failwith "Update Servers geewallet operation failed ^"
+        failwith "Update Servers operation failed ^"
     | _ -> ()
 
     let gitAddJson =

--- a/src/GWallet.Backend/Config.fs
+++ b/src/GWallet.Backend/Config.fs
@@ -13,6 +13,9 @@ open GWallet.Backend.FSharpUtil.UwpHacks
 // TODO: make internal when tests don't depend on this anymore
 module Config =
 
+    [<Literal>]
+    let AppName = "geewallet"
+
     // we might want to test with TestNet at some point, so this below is the key:
     // (but we would need to get a seed list of testnet electrum servers, and testnet(/ropsten/rinkeby?), first...)
     let BitcoinNet = NBitcoin.Network.Main

--- a/src/GWallet.Backend/Ether/EtherServer.fs
+++ b/src/GWallet.Backend/Ether/EtherServer.fs
@@ -288,7 +288,7 @@ module Server =
             | Some deserEx ->
                 raise <| ServerMisconfiguredException(deserEx.Message, ex)
 
-            // this SSL exception could be a mono 6.0.x bug (see https://gitlab.com/knocte/geewallet/issues/121)
+            // this SSL exception could be a mono 6.0.x bug (see https://gitlab.com/nblockchain/geewallet/issues/121)
             let maybeHttpReqEx = FSharpUtil.FindException<Http.HttpRequestException> ex
             match maybeHttpReqEx with
             | Some httpReqEx ->
@@ -301,7 +301,7 @@ module Server =
                     raise <| ServerCannotBeResolvedException(httpReqEx.InnerException.Message, ex)
 *)
 
-                // this could be a mono 6.0.x bug (see https://gitlab.gnome.org/World/geewallet/issues/121)
+                // this could be a mono 6.0.x bug (see https://gitlab.com/nblockchain/geewallet/issues/121)
                 if httpReqEx.Message.Contains "SSL" then
                     let maybeIOEx = FSharpUtil.FindException<IOException> ex
                     match maybeIOEx with

--- a/src/GWallet.Backend/Server.fs
+++ b/src/GWallet.Backend/Server.fs
@@ -124,10 +124,10 @@ module ServerRegistry =
             // they create exception when being queried for advanced ones (e.g. latest block)
             server.ServerInfo.NetworkPath.Contains "blockscout" ||
 
-            // there was a mistake when adding this server to geewallet's JSON: it was added in the ETC currency instead of ETH
+            // there was a mistake when adding this server to our servers.json file: it was added in the ETC currency instead of ETH
             (currency = Currency.ETC && server.ServerInfo.NetworkPath.Contains "ethrpc.mewapi.io")
 
-            // there was a typo when adding this server to geewallet's JSON, see commit 69d90fd2fc22a1f3dd9ef8793f0cd42e3b540df1
+            // there was a typo when adding this server to our servers.json file, see commit 69d90fd2fc22a1f3dd9ef8793f0cd42e3b540df1
             || (currency = Currency.ETC && server.ServerInfo.NetworkPath.Contains "ethercluster.comx/")
 
         let currency,servers = cs

--- a/src/GWallet.Backend/UtxoCoin/ElectrumClient.fs
+++ b/src/GWallet.Backend/UtxoCoin/ElectrumClient.fs
@@ -12,7 +12,7 @@ module ElectrumClient =
         let stratumClient = new StratumClient(jsonRpcClient)
 
         // this is the last version of Electrum released at the time of writing this module
-        let CLIENT_NAME_SENT_TO_STRATUM_SERVER_WHEN_HELLO = "geewallet"
+        let CLIENT_NAME_SENT_TO_STRATUM_SERVER_WHEN_HELLO = Config.AppName
 
         // last version of the protocol [1] as of electrum's source code [2] at the time of
         // writing this... actually this changes relatively rarely (one of the last changes

--- a/src/GWallet.Backend/UtxoCoin/UtxoCoinAccount.fs
+++ b/src/GWallet.Backend/UtxoCoin/UtxoCoinAccount.fs
@@ -308,7 +308,7 @@ module Account =
                     // Avoid querying for zero-value UTXOs, which would make many unnecessary parallel
                     // connections to Electrum servers. (there's no need to use/consolidate zero-value UTXOs)
 
-                    // This can be triggered on e.g. RegTest (by mining to Geewallet directly)
+                    // This can be triggered on e.g. RegTest (by mining to geewallet directly)
                     // because the block subsidy falls quickly. (it will be 0 after 7000 blocks)
 
                     // Zero-value OP_RETURN outputs are valid and standard:
@@ -381,7 +381,7 @@ module Account =
                 Money(btcPerKiloByteForFastTrans, MoneyUnit.BTC) |> FeeRate
             with
             | ex ->
-                // we need more info in case this bug shows again: https://gitlab.com/knocte/geewallet/issues/43
+                // we need more info in case this bug shows again: https://gitlab.com/nblockchain/geewallet/issues/43
                 raise <| Exception(SPrintF1 "Could not create fee rate from %s btc per KB"
                                            (btcPerKiloByteForFastTrans.ToString()), ex)
 

--- a/src/GWallet.Frontend.Console/Program.fs
+++ b/src/GWallet.Frontend.Console/Program.fs
@@ -527,7 +527,9 @@ module Program =
         | 0 ->
             NormalStartWithNoParameters()
         | 1 when argv.[0] = "--version" ->
-            Console.WriteLine (sprintf "geewallet v%s" VersionHelper.CURRENT_VERSION)
+            Console.WriteLine (
+                sprintf "%s v%s" Config.AppName VersionHelper.CURRENT_VERSION
+            )
             0
         | 1 when argv.[0] = "--update-servers-file" ->
             UpdateServersFile()

--- a/src/GWallet.Frontend.XF.Android/MainActivity.fs
+++ b/src/GWallet.Frontend.XF.Android/MainActivity.fs
@@ -14,7 +14,7 @@ open Xamarin.Forms.Platform.Android
 type Resources = GWallet.Frontend.XF.Android.Resource
 
 [<Activity (LaunchMode = LaunchMode.SingleTask, 
-            Label = "geewallet", 
+            Label = GWallet.Backend.Config.AppName,
             Icon = "@drawable/icon", 
             Theme = "@style/MyTheme", 
             MainLauncher = true, 

--- a/src/GWallet.Frontend.XF.Gtk/Program.fs
+++ b/src/GWallet.Frontend.XF.Gtk/Program.fs
@@ -22,11 +22,16 @@ module Main =
         let app = GWallet.Frontend.XF.App()
         use window = new FormsWindow()
         window.LoadApplication(app)
-        window.SetApplicationTitle "geewallet"
+        window.SetApplicationTitle Config.AppName
         let snapEnvVar = Environment.GetEnvironmentVariable "SNAP"
         let logoFileName = "logo.png"
         if not (String.IsNullOrEmpty snapEnvVar) then
-            window.SetApplicationIcon (SPrintF2 "%s/lib/geewallet/%s" (snapEnvVar.TrimEnd('/')) logoFileName)
+            window.SetApplicationIcon (
+                SPrintF3 "%s/lib/%s/%s"
+                    (snapEnvVar.TrimEnd('/'))
+                    Config.AppName
+                    logoFileName
+            )
         else
             window.SetApplicationIcon logoFileName
         window.SetDefaultSize (500, 1000)
@@ -41,7 +46,11 @@ module Main =
         | 0 ->
             NormalStartWithNoParameters()
         | 1 when argv.[0] = "--version" ->
-            Console.WriteLine (SPrintF1 "geewallet v%s" VersionHelper.CURRENT_VERSION)
+            Console.WriteLine (
+                SPrintF2 "%s v%s"
+                    Config.AppName
+                    VersionHelper.CURRENT_VERSION
+            )
             0
         | 1 when argv.[0] = "--console" ->
             GWallet.Frontend.Console.Program.Main Array.empty

--- a/src/GWallet.Frontend.XF/PairingToPage.xaml.fs
+++ b/src/GWallet.Frontend.XF/PairingToPage.xaml.fs
@@ -10,6 +10,7 @@ open ZXing.Net.Mobile.Forms
 open Fsdk
 
 open GWallet.Backend
+open GWallet.Backend.FSharpUtil.UwpHacks
 
 type PairingToPage(balancesPage: Page,
                    normalAccountsBalanceSets: seq<BalanceSet>,
@@ -73,7 +74,9 @@ type PairingToPage(balancesPage: Page,
         let watchWalletInfoJson = coldAddressesEntry.Text
         match Deserialize watchWalletInfoJson with
         | None ->
-            let msg = "Invalid pairing info format (should be JSON). Did you pair a QR-code from another geewallet instance?"
+            let msg =
+                SPrintF1 "Invalid pairing info format (should be JSON). Did you pair a QR-code from another %s instance?"
+                    Config.AppName
             MainThread.BeginInvokeOnMainThread(fun _ ->
                 self.DisplayAlert("Alert", msg, "OK")
                     |> FrontendHelpers.DoubleCheckCompletionNonGeneric

--- a/src/GWallet.Frontend.XF/WelcomePage.xaml
+++ b/src/GWallet.Frontend.XF/WelcomePage.xaml
@@ -7,7 +7,7 @@
                  RowDefinitions="*,*,Auto,Auto,Auto,Auto,Auto"
                  VerticalOptions="Center"
                  Padding="20,20,20,20">
-        <Label Text="Welcome to geewallet" x:Name="welcomeLabel"
+        <Label Text="Welcome" x:Name="welcomeLabel"
                VerticalOptions="Center" HorizontalOptions="Center"
                FontSize="Large"
                Margin="20,20,20,20"

--- a/src/GWallet.Frontend.XF/WelcomePage.xaml.fs
+++ b/src/GWallet.Frontend.XF/WelcomePage.xaml.fs
@@ -16,6 +16,8 @@ type WelcomePage(state: FrontendHelpers.IGlobalAppState) =
     let _ = base.LoadFromXaml(typeof<WelcomePage>)
 
     let mainLayout = base.FindByName<Grid> "mainLayout"
+    let welcomeLabel = mainLayout.FindByName<Label> "welcomeLabel"
+
     let infoGrid = mainLayout.FindByName<Grid> "infoGrid"
     let passphraseEntry = mainLayout.FindByName<Entry> "passphraseEntry"
     let passphraseConfirmationEntry = mainLayout.FindByName<Entry> "passphraseConfirmationEntry"
@@ -96,6 +98,7 @@ type WelcomePage(state: FrontendHelpers.IGlobalAppState) =
         )
 
     do
+        welcomeLabel.Text <- SPrintF1 "Welcome to %s" Config.AppName
         dobDatePicker.MaximumDate <- DateTime.UtcNow.Date
         dobDatePicker.Date <- middleDateEighteenYearsAgo
 
@@ -153,7 +156,12 @@ type WelcomePage(state: FrontendHelpers.IGlobalAppState) =
             submit () |> FrontendHelpers.DoubleCheckCompletionAsync false
 
     member private self.DisplayInfo() =
-        self.DisplayAlert("Info", "Please note that geewallet is a brain-wallet, which means that this personal information is not registered in any server or any location outside your device, not even saved in your device. It will just be combined and hashed to generate a unique secret which is called a 'private key' which will allow you to recover your funds if you install the application again (in this or other device) later. \r\n\r\n(If it is your first time using this wallet and just want to test it quickly without any funds or low amounts, you can just input any data that is long enough to be considered valid.)", "OK")
+        self.DisplayAlert(
+            "Info",
+            SPrintF1 "Please note that %s is a brain-wallet, which means that this personal information is not registered in any server or any location outside your device, not even saved in your device. It will just be combined and hashed to generate a unique secret which is called a 'private key' which will allow you to recover your funds if you install the application again (in this or other device) later. \r\n\r\n(If it is your first time using this wallet and just want to test it quickly without any funds or low amounts, you can just input any data that is long enough to be considered valid.)"
+                Config.AppName,
+            "OK"
+        )
 
     member self.OnMoreInfoButtonClicked(_sender: Object, _args: EventArgs) =
         self.DisplayInfo


### PR DESCRIPTION
Prepare for a possible rebranding, by respecting DRY in many
places. While we're at it, we also converge some URLs to one
single format and issue tracker (moving from old/non-canonical
ones), fix some casing occurence (for easier rename later),
and remove app name usage where there's no need to.