### PR TITLE
WIP: add ubuntu 24.04 lanes to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -188,6 +188,212 @@ jobs:
 
         find . -type f -name "*.fsx" | xargs -t -I {} dotnet fsxc {}
 
+
+  # TODO: add linux24-github--dotnet-and-newmono & linux24-github--dotnet-and-mono when runs-on has 'ubuntu-24.04'
+  #       ( https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories )
+
+  linux24-vanilla--stockmono-only:
+    runs-on: ubuntu-22.04
+    container:
+      image: "ubuntu:24.04"
+    steps:
+    - uses: actions/checkout@v1
+    # can't use the option below because of error "Input 'submodules' not supported when falling back to download using the GitHub REST API. To create a local Git repository instead, add Git 2.18 or higher to the PATH."
+    #  with:
+    #    submodules: 'true'
+
+    - name: install sudo
+      run: apt update && apt install --yes sudo
+    - name: install all dependencies
+      run: sudo DEBIAN_FRONTEND=noninteractive apt install --yes git make curl fsharp nunit-console
+
+    # workaround for https://github.com/actions/runner/issues/2033
+    - name: ownership workaround
+      run: git config --global --add safe.directory '*'
+
+    - name: check mono version
+      run: mono --version
+    - name: configure
+      run: ./configure.sh
+    - name: build in DEBUG mode
+      run: make
+    - name: sanity check
+      run: make sanitycheck
+    - name: unit tests
+      run: make check
+    - name: build in STRICT mode
+      run: git clean -fdx && ./configure.sh && make strict
+    - name: build in RELEASE mode
+      run: git clean -fdx && ./configure.sh && make release
+    - name: integration tests
+      run: make update-servers
+
+  linux24-vanilla--stockdotnet8-only:
+    runs-on: ubuntu-22.04
+    container:
+      image: "ubuntu:24.04"
+    steps:
+    - uses: actions/checkout@v1
+    # can't use the option below because of error "Input 'submodules' not supported when falling back to download using the GitHub REST API. To create a local Git repository instead, add Git 2.18 or higher to the PATH."
+    #  with:
+    #    submodules: 'true'
+
+    - name: install sudo
+      run: apt update && apt install --yes sudo
+    - name: install all dependencies
+      run: sudo DEBIAN_FRONTEND=noninteractive apt install --yes git make curl dotnet8
+
+    # workaround for https://github.com/actions/runner/issues/2033
+    - name: ownership workaround
+      run: git config --global --add safe.directory '*'
+
+    - name: configure
+      run: ./configure.sh
+    - name: build in DEBUG mode
+      run: make
+    - name: sanity check
+      run: make sanitycheck
+    - name: unit tests
+      run: make check
+    - name: build in STRICT mode
+      run: git clean -fdx && ./configure.sh && make strict
+    - name: build in RELEASE mode
+      run: git clean -fdx && ./configure.sh && make release
+    - name: integration tests
+      run: make update-servers
+    - name: compile .fsx scripts
+      run: |
+        dotnet new tool-manifest
+
+        # we need to install specific version because of this bug: https://github.com/dotnet/sdk/issues/24037
+        dotnet tool install fsxc --version 0.5.9.1
+
+        find . -type f -name "*.fsx" | xargs -t -I {} dotnet fsxc {}
+
+  linux24-vanilla--stockdotnet8-and-newmono:
+    runs-on: ubuntu-22.04
+    container:
+      image: "ubuntu:24.04"
+    steps:
+    - uses: actions/checkout@v1
+    # can't use the option below because of error "Input 'submodules' not supported when falling back to download using the GitHub REST API. To create a local Git repository instead, add Git 2.18 or higher to the PATH."
+    #  with:
+    #    submodules: 'true'
+
+    - name: install sudo
+      run: apt update && apt install --yes sudo
+    - name: install all dependencies
+      run: sudo DEBIAN_FRONTEND=noninteractive apt install --yes git make curl dotnet8
+    - name: install last version of mono (Microsoft APT repositories)
+      run: sudo ./scripts/install_mono_from_microsoft_deb_packages.sh
+
+    # workaround for https://github.com/actions/runner/issues/2033
+    - name: ownership workaround
+      run: git config --global --add safe.directory '*'
+
+    - name: configure
+      run: ./configure.sh
+    - name: build in DEBUG mode
+      run: make
+    - name: sanity check
+      run: make sanitycheck
+    - name: unit tests
+      run: make check
+    - name: build in STRICT mode
+      run: git clean -fdx && ./configure.sh && make strict
+    - name: build in RELEASE mode
+      run: git clean -fdx && ./configure.sh && make release
+    - name: integration tests
+      run: make update-servers
+    - name: compile .fsx scripts
+      run: |
+        dotnet new tool-manifest
+
+        # we need to install specific version because of this bug: https://github.com/dotnet/sdk/issues/24037
+        dotnet tool install fsxc --version 0.5.9.1
+
+        find . -type f -name "*.fsx" | xargs -t -I {} dotnet fsxc {}
+
+  linux24-vanilla--stockdotnet8-and-stockmono:
+    runs-on: ubuntu-22.04
+    container:
+      image: "ubuntu:24.04"
+    steps:
+    - uses: actions/checkout@v1
+    # can't use the option below because of error "Input 'submodules' not supported when falling back to download using the GitHub REST API. To create a local Git repository instead, add Git 2.18 or higher to the PATH."
+    #  with:
+    #    submodules: 'true'
+
+    - name: install sudo
+      run: apt update && apt install --yes sudo
+    - name: install all dependencies
+      run: sudo DEBIAN_FRONTEND=noninteractive apt install --yes git make curl dotnet8 mono-xbuild
+
+    # workaround for https://github.com/actions/runner/issues/2033
+    - name: ownership workaround
+      run: git config --global --add safe.directory '*'
+
+    - name: configure
+      run: ./configure.sh
+    - name: build in DEBUG mode
+      run: make
+    - name: sanity check
+      run: make sanitycheck
+    - name: unit tests
+      run: make check
+    - name: build in STRICT mode
+      run: git clean -fdx && ./configure.sh && make strict
+    - name: build in RELEASE mode
+      run: git clean -fdx && ./configure.sh && make release
+    - name: integration tests
+      run: make update-servers
+    - name: compile .fsx scripts
+      run: |
+        dotnet new tool-manifest
+
+        # we need to install specific version because of this bug: https://github.com/dotnet/sdk/issues/24037
+        dotnet tool install fsxc --version 0.5.9.1
+
+        find . -type f -name "*.fsx" | xargs -t -I {} dotnet fsxc {}
+
+  linux24-vanilla--newmono-only:
+    runs-on: ubuntu-22.04
+    container:
+      image: "ubuntu:24.04"
+    steps:
+    - uses: actions/checkout@v1
+    # can't use the option below because of error "Input 'submodules' not supported when falling back to download using the GitHub REST API. To create a local Git repository instead, add Git 2.18 or higher to the PATH."
+    #  with:
+    #    submodules: 'true'
+
+    - name: install sudo
+      run: apt update && apt install --yes sudo
+    - name: install all dependencies
+      run: sudo DEBIAN_FRONTEND=noninteractive apt install --yes git make curl fsharp nunit-console
+    - name: install last version of mono (Microsoft APT repositories)
+      run: sudo ./scripts/install_mono_from_microsoft_deb_packages.sh
+
+    # workaround for https://github.com/actions/runner/issues/2033
+    - name: ownership workaround
+      run: git config --global --add safe.directory '*'
+
+    - name: check mono version
+      run: mono --version
+    - name: configure
+      run: ./configure.sh
+    - name: build in DEBUG mode
+      run: make
+    - name: sanity check
+      run: make sanitycheck
+    - name: unit tests
+      run: make check
+    - name: build in STRICT mode
+      run: git clean -fdx && ./configure.sh && make strict
+    - name: build in RELEASE mode
+      run: git clean -fdx && ./configure.sh && make release
+    - name: integration tests
+      run: make update-servers
+
   linux22-github--dotnet-and-mono:
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
Non-vanilla is not available yet, otherwise it would appear in the docs:
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories