### PR TITLE
ReadMe: add canary wallets & BIP352 & Bech32m [no ci]

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -83,9 +83,10 @@ This list is the (intended) order of preference for new features:
 (See: https://www.reddit.com/r/Bitcoin/comments/7hsq6m/symbol_for_a_bit_0000001btc/ or in case we end up using sats, this "1 over 2" idea is interesting: 
 https://twitter.com/Parman_Public/status/1603698639947599873 )
 - MimbleWimble(LTC) support (WIP, see https://github.com/nblockchain/NLitecoin/pull/2 ).
-- Threshold signatures (or asynchronous ones? see https://twitter.com/real_or_random/status/1523964246945636352 ).
+- Multi-sig support via Threshold signatures (or asynchronous ones? see https://twitter.com/real_or_random/status/1523964246945636352 ) with Canary wallets (https://twitter.com/_benkaufman/status/1788601994451562695).
 - Use deniable encryption to allow for a duress password/passphrase/pin.
-- Multi-sig support?
+- BIP352: Silent Payments (as an extra justification against BIP32: e.g. gap limits), see https://twitter.com/reardencode/status/1788577217884364861 .
+- Bech32m support, see https://x.com/murchandamus/status/1794014556513046721 .
 - Fee selection for custom priority (so that our RBF support becomes actually useful).
 - ETH gas station (to pay for token transactions with token value instead of ETH).
 - Crosschain atomic swaps (via [comit network](https://github.com/comit-network/comit-rs)? more info [here](https://blog.coblox.tech/2018/06/23/connect-all-the-blockchains.html) and [here](https://blog.coblox.tech/2018/12/12/erc20-lightning-and-COMIT.html)).


### PR DESCRIPTION
Problem about BIP351 is:
* Need electrum-server support.
* Still vulnerable to UTXO consolidation problems (which could be mitigated with PayJoin...).

All in all, great features but still on-chain tech.