### PR TITLE
Backend/Caching: save(&restore) .bak files

### DIFF
--- a/src/GWallet.Backend/Exceptions.fs
+++ b/src/GWallet.Backend/Exceptions.fs
@@ -23,7 +23,7 @@ exception AccountAlreadyAdded
 
 exception InvalidDestinationAddress of msg: string
 
-exception InvalidJson
+exception InvalidJson of content: string
 
 exception TransactionAlreadySigned
 exception TransactionNotSignedYet

--- a/src/GWallet.Backend/Marshalling.fs
+++ b/src/GWallet.Backend/Marshalling.fs
@@ -175,7 +175,7 @@ module Marshalling =
         if (String.IsNullOrWhiteSpace(json)) then
             raise (ArgumentException("empty or whitespace json", "json"))
         if not (IsValidJson json) then
-            raise <| InvalidJson
+            raise <| InvalidJson json
 
         let deserialized =
             try

--- a/src/GWallet.Frontend.Console/Program.fs
+++ b/src/GWallet.Frontend.Console/Program.fs
@@ -246,7 +246,7 @@ module Program =
                 Marshalling.Deserialize watchWalletInfoJson
                 |> Some
             with
-            | InvalidJson ->
+            | InvalidJson _content ->
                 None
 
         match watchWalletInfoOpt with


### PR DESCRIPTION
We've had one occassion already where a wallet instance was
crashing at start somehow finding invalid JSON. In this case
we can just discard the data and recreate (because it's cache)
however we can do better and just use backups.

TODO:
[ ] Eliminate duplication in last commit.
[ ] Create LoadFromDisk APIs that manage bak save&restore automatically.