### PR TITLE
Backend: handle null response from Eth server

### DIFF
--- a/src/GWallet.Backend/Ether/EtherExceptions.fs
+++ b/src/GWallet.Backend/Ether/EtherExceptions.fs
@@ -33,6 +33,7 @@ type RpcErrorCode =
     | CannotFulfillRequest = -32046
     | ResourceNotFound = -32001
     | InternalError = -32603
+    | UnparsableResponseType = -39000
 
 type ServerCannotBeResolvedException =
     inherit CommunicationUnsuccessfulException

--- a/src/GWallet.Backend/Ether/EtherExceptions.fs
+++ b/src/GWallet.Backend/Ether/EtherExceptions.fs
@@ -95,3 +95,10 @@ type UnhandledWebException =
         }
     new (info: SerializationInfo, context: StreamingContext) =
         { inherit Exception (info, context) }
+
+/// Exception indicating that response JSON contains null value where it should not.
+/// E.g. {"jsonrpc":"2.0","id":1,"result":null}
+type AbnormalNullValueInJsonResponseException(message: string) =
+    inherit CommunicationUnsuccessfulException(message)
+
+    static member BalanceJobErrorMessage = "Abnormal null response from balance job"

--- a/src/GWallet.Backend/Ether/EtherServer.fs
+++ b/src/GWallet.Backend/Ether/EtherServer.fs
@@ -226,6 +226,8 @@ module Server =
                     raise <| ServerMisconfiguredException(exMsg, rpcResponseEx)
                 | i when i = int RpcErrorCode.InternalError ->
                     raise <| ServerFaultException(exMsg, rpcResponseEx)
+                | j when j = int RpcErrorCode.UnparsableResponseType ->
+                    raise <| ServerFaultException(exMsg, rpcResponseEx)
                 | _ ->
                     raise
                     <| Exception (SPrintF3 "RpcResponseException with RpcError Code <%i> and Message '%s' (%s)"

--- a/src/GWallet.Backend/Ether/EtherServer.fs
+++ b/src/GWallet.Backend/Ether/EtherServer.fs
@@ -136,6 +136,8 @@ module Server =
                 raise <| ServerTimedOutException(exMsg, httpReqEx)
             if HttpRequestExceptionMatchesErrorCode httpReqEx (int CloudFlareError.OriginUnreachable) then
                 raise <| ServerTimedOutException(exMsg, httpReqEx)
+            if HttpRequestExceptionMatchesErrorCode httpReqEx (int HttpStatusCode.RequestTimeout) then
+                raise <| ServerTimedOutException(exMsg, httpReqEx)
 
             if HttpRequestExceptionMatchesErrorCode httpReqEx (int CloudFlareError.OriginSslHandshakeError) then
                 raise <| ServerChannelNegotiationException(exMsg, CloudFlareError.OriginSslHandshakeError, httpReqEx)

--- a/src/GWallet.Backend/Ether/EtherServer.fs
+++ b/src/GWallet.Backend/Ether/EtherServer.fs
@@ -549,7 +549,7 @@ module Server =
                                 let task = web3.Eth.GetBalance.SendRequestAsync (address, null, cancelToken)
                                 return! Async.AwaitTask task
                             }
-                    if Object.ReferenceEquals(balance, null) then
+                    if isNull balance then
                         raise <| 
                             AbnormalNullValueInJsonResponseException 
                                 AbnormalNullValueInJsonResponseException.BalanceJobErrorMessage

--- a/src/GWallet.Backend/Ether/EtherServer.fs
+++ b/src/GWallet.Backend/Ether/EtherServer.fs
@@ -543,7 +543,9 @@ module Server =
                                 return! Async.AwaitTask task
                             }
                     if Object.ReferenceEquals(balance, null) then
-                        failwith "Weird null response from balance job"
+                        raise <| 
+                            AbnormalNullValueInJsonResponseException 
+                                AbnormalNullValueInJsonResponseException.BalanceJobErrorMessage
                     return UnitConversion.Convert.FromWei(balance.Value, UnitConversion.EthUnit.Ether)
                 }
                 GetRandomizedFuncs currency web3Func

--- a/src/GWallet.Backend/Ether/EtherServer.fs
+++ b/src/GWallet.Backend/Ether/EtherServer.fs
@@ -464,7 +464,10 @@ module Server =
                             let! cancelToken = Async.CancellationToken
                             let task =
                                 web3.Eth.Transactions.GetTransactionCount.SendRequestAsync(address, null, cancelToken)
-                            return! Async.AwaitTask task
+                            let! txCount = Async.AwaitTask task
+                            if isNull txCount then
+                                raise <| AbnormalNullValueInJsonResponseException "Abnormal null response from tx count job"
+                            return txCount
                         }
                 GetRandomizedFuncs currency web3Func
             return! faultTolerantEtherClient.Query
@@ -480,7 +483,7 @@ module Server =
                 web3.Eth.Blocks.GetBlockNumber.SendRequestAsync (null, cancelToken)
                     |> Async.AwaitTask
             if isNull latestBlock then
-                failwith "latestBlock somehow is null"
+                raise <| AbnormalNullValueInJsonResponseException "latestBlock somehow is null"
 
             let blockToCheck = BigInteger.Subtract(latestBlock.Value,
                                                    NUMBER_OF_CONFIRMATIONS_TO_CONSIDER_BALANCE_CONFIRMED)
@@ -575,7 +578,7 @@ module Server =
 
             let contractHandler = web3.Eth.GetContractHandler contractAddress
             if isNull contractHandler then
-                failwith "contractHandler somehow is null"
+                raise <| AbnormalNullValueInJsonResponseException "contractHandler somehow is null"
 
             let! cancelToken = Async.CancellationToken
             cancelToken.ThrowIfCancellationRequested()
@@ -637,7 +640,10 @@ module Server =
                             let! cancelToken = Async.CancellationToken
                             let task =
                                 contractHandler.EstimateGasAsync<TransferFunction>(transferFunctionMsg, cancelToken)
-                            return! Async.AwaitTask task
+                            let! fee = Async.AwaitTask task
+                            if isNull fee then
+                                raise <| AbnormalNullValueInJsonResponseException "Abnormal null response from transfer fee job"
+                            return fee
                     }
                 GetRandomizedFuncs account.Currency web3Func
             return! faultTolerantEtherClient.Query
@@ -660,6 +666,8 @@ module Server =
                             let! cancelToken = Async.CancellationToken
                             let task = web3.Eth.GasPrice.SendRequestAsync(null, cancelToken)
                             let! hexBigInteger = Async.AwaitTask task
+                            if isNull hexBigInteger then
+                                raise <| AbnormalNullValueInJsonResponseException "Abnormal null response from gas price job"
                             if hexBigInteger.Value = BigInteger 0 then
                                 return failwith "Some server returned zero for gas price, which is invalid"
                             return hexBigInteger
@@ -690,7 +698,12 @@ module Server =
                             let! cancelToken = Async.CancellationToken
                             let task =
                                 web3.Eth.Transactions.SendRawTransaction.SendRequestAsync(transaction, null, cancelToken)
-                            return! Async.AwaitTask task
+                            let! response = Async.AwaitTask task
+                            if isNull response then
+                                raise <|
+                                    AbnormalNullValueInJsonResponseException
+                                        "Abnormal null response from broadcast transaction job"
+                            return response
                         }
                 GetRandomizedFuncs currency web3Func
             try
@@ -721,6 +734,10 @@ module Server =
                         let task =
                             web3.TransactionManager.TransactionReceiptService.PollForReceiptAsync(txHash, cancelToken)
                         let! transactionReceipt = Async.AwaitTask task
+                        if isNull transactionReceipt || isNull transactionReceipt.GasUsed || isNull transactionReceipt.Status then
+                            raise <| 
+                                AbnormalNullValueInJsonResponseException
+                                    (SPrintF1 "Abnormal null response when getting details from tx receipt (%A)" transactionReceipt)
                         return {
                             GasUsed = transactionReceipt.GasUsed.Value
                             Status = transactionReceipt.Status.Value

--- a/src/GWallet.Backend/ServerManager.fs
+++ b/src/GWallet.Backend/ServerManager.fs
@@ -128,6 +128,10 @@ module ServerManager =
                 let web3Func (web3: Ether.SomeWeb3): Async<decimal> =
                     async {
                         let! balance = Async.AwaitTask (web3.Eth.GetBalance.SendRequestAsync ETH_GENESISBLOCK_ADDRESS)
+                        if isNull balance then
+                            raise <| 
+                                Ether.AbnormalNullValueInJsonResponseException 
+                                    Ether.AbnormalNullValueInJsonResponseException.BalanceJobErrorMessage
                         return balance.Value |> decimal
                     }
 


### PR DESCRIPTION
Introduce WeirdNullResponseException type and raise it when response for balance request for Ethereum returns json with "result" field value of `null`. This way server will be marked as faulty instead of crashing the application.

Fixes https://github.com/nblockchain/geewallet/issues/282