### PR TITLE
CI: upgrade fsxc to 0.6.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   # we need to install specific version because of this bug: https://github.com/dotnet/sdk/issues/24037
-  FSXC_VERSION: 0.5.9.1
+  FSXC_VERSION: 0.6.0
 
 # FIXME: figure out why we need to clean after make if we
 # want 'make strict' target to really happen without


### PR DESCRIPTION
It is the last stable version that will work in
dotnet v6.x runtime (next versions will be for 7.x and/or 8.x).