### PR TITLE
GithubCI: switch to MacOS 13

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   macOS--dotnet6-and-mono:
-    runs-on: macOS-12
+    runs-on: macOS-13
     steps:
     - uses: actions/checkout@v1
       with:
@@ -26,6 +26,17 @@ jobs:
       uses: actions/setup-dotnet@v1.7.2
       with:
         dotnet-version: '6.0.113'
+    - name: Install specific Xamarin.iOS and Xamarin.Android versions
+      run: |
+        wget https://download.visualstudio.microsoft.com/download/pr/81c41aaa-a3d7-4875-8416-d04b472379b7/21d9f6c5ad3a6bc2479b2ec4b0685b6c/xamarin.ios-16.0.0.72.pkg
+        sudo installer -pkg xamarin.ios-16.0.0.72.pkg -target /
+        wget https://aka.ms/xamarin-android-commercial-d17-3-macos --output-document=xamarin.android-13.0.0.0.pkg
+        sudo installer -pkg xamarin.android-13.0.0.0.pkg -target /
+    - name: Check versions
+      run: |
+        mono --version
+        /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mtouch --version
+        ls -l /Library/Frameworks/Xamarin.Android.framework/Versions/
     - name: configure
       run: ./configure.sh
     - name: build in DEBUG mode
@@ -50,13 +61,24 @@ jobs:
         find . -type f -name "*.fsx" | xargs -t -I {} dotnet fsxc {}
 
   macOS--mono-only:
-    runs-on: macOS-12
+    runs-on: macOS-13
     steps:
     - uses: actions/checkout@v1
       with:
         submodules: false
     - name: HACK to emulate dotnet uninstall
       run: sudo rm -f `which dotnet`
+    - name: Install specific Xamarin.iOS and Xamarin.Android versions
+      run: |
+        wget https://download.visualstudio.microsoft.com/download/pr/81c41aaa-a3d7-4875-8416-d04b472379b7/21d9f6c5ad3a6bc2479b2ec4b0685b6c/xamarin.ios-16.0.0.72.pkg
+        sudo installer -pkg xamarin.ios-16.0.0.72.pkg -target /
+        wget https://aka.ms/xamarin-android-commercial-d17-3-macos --output-document=xamarin.android-13.0.0.0.pkg
+        sudo installer -pkg xamarin.android-13.0.0.0.pkg -target /
+    - name: Check versions
+      run: |
+        mono --version
+        /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/bin/mtouch --version
+        ls -l /Library/Frameworks/Xamarin.Android.framework/Versions/
     - name: configure
       run: ./configure.sh
     - name: build in DEBUG mode
@@ -73,11 +95,15 @@ jobs:
       run: make update-servers
 
   macOS--dotnet6-only:
-    runs-on: macOS-12
+    runs-on: macOS-13
     steps:
     - uses: actions/checkout@v1
       with:
         submodules: false
+    - name: Setup .NET SDK 6.0.x
+      uses: actions/setup-dotnet@v1.7.2
+      with:
+        dotnet-version: '6.0.113'        
     - name: HACK to emulate mono uninstall
       run: sudo rm -f `which mono` && sudo rm -f `which msbuild`
     - name: configure


### PR DESCRIPTION
- Changed MacOS version used in CI to 13, as version 12 got
deprecated [1] and causes the jobs to be cancelled.
- Installed specific versions of Xamarin.iOS & Xamarin.Android
(the same as on MacOS 12), because MacOS 13 doesn't come with
Xamarin preinstalled, and build fails with error:
```
/Users/runner/work/geewallet/geewallet/src/GWallet.Frontend.XF.iOS/GWallet.Frontend.XF.iOS.fsproj(92,11): error MSB4226: The imported project "/Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/xbuild/Xamarin/iOS/Xamarin.iOS.FSharp.targets" was not found. Also, tried to find "Xamarin/iOS/Xamarin.iOS.FSharp.targets" in the fallback search path(s) for $(MSBuildExtensionsPath) - "/Library/Frameworks/Mono.framework/External/xbuild/" . These search paths are defined in "/Library/Frameworks/Mono.framework/Versions/6.12.0/lib/mono/msbuild/Current/bin/MSBuild.dll.config". Confirm that the path in the <Import> declaration is correct, and that the file exists on disk in one of the search paths.
```
- Installed .NET6 in `macOS--dotnet6-only` and
`macOS--dotnet6-and-mono` jobs, because default .NET version
on MacOS 13 is 8.0.404.

One thing to note is that now `macOS--mono-only` and
`macOS--dotnet6-only` take more time (20-25 minutes) and
became the slowest jobs.

[1] https://github.com/actions/runner-images/issues/10721