### PR TITLE
scripts: bump Microsoft.Build nuget ref to fix sanitycheck CI failure

### DIFF
--- a/scripts/sanitycheck.fsx
+++ b/scripts/sanitycheck.fsx
@@ -31,7 +31,7 @@ open GWallet.Scripting
 #if LEGACY_FRAMEWORK
 #r "../.nuget/packages/Microsoft.Build.16.11.0/lib/net472/Microsoft.Build.dll"
 #else
-#r "nuget: Microsoft.Build, Version=16.11.0"
+#r "nuget: Microsoft.Build, Version=17.3.0"
 #endif
 open Microsoft.Build.Construction
 


### PR DESCRIPTION
Fixes the "sanity check" CI step failing in 9 lanes with `Fsdk.Process+ProcessSucceededWithWarnings` thrown from `make.fsx:529` (reported in nblockchain/conventions#351).

## Root cause

`make.fsx`'s `sanitycheck` target runs `scripts/sanitycheck.fsx` via `dotnet fsi`, which restores the script's `#r "nuget: Microsoft.Build, Version=16.11.0"` reference. `Microsoft.Build` 16.11.0 transitively depends on `System.Drawing.Common` 4.7.0, which has a known **critical** severity vulnerability ([GHSA-rxg9-xrhp-64gj](https://github.com/advisories/GHSA-rxg9-xrhp-64gj), CVSS 9.8), via:

```
Microsoft.Build 16.11.0
  -> Microsoft.Build.Framework 16.11.0 (and System.Configuration.ConfigurationManager 4.7.0)
    -> System.Security.Permissions 4.7.0
      -> System.Windows.Extensions 4.7.0
        -> System.Drawing.Common 4.7.0
```

Starting with the .NET 9/10 SDKs, NuGet audit is enabled by default during restore, so `dotnet fsi`'s implicit restore of the `#r "nuget:"` reference now prints:

```
warning NU1904: Package 'System.Drawing.Common' 4.7.0 has a known critical severity vulnerability, https://github.com/advisories/GHSA-rxg9-xrhp-64gj
```

on stderr, even though the process exits 0. `Fsdk.Process` classifies an exit-code-0 process with any stderr output as `WarningsOrAmbiguous`, so `.UnwrapDefault()` throws `ProcessSucceededWithWarnings`, failing the "sanity check" step in every `dotnet fsi`-based CI lane (Ubuntu 22/24, macOS, `windows--dotnet-only`, `windows--dotnet-and-legacyFramework`). This isn't specific to any branch — `master`'s scheduled CI has been failing daily since GitHub's runner images picked up a newer SDK.

The `windows--legacyFramework-only` lane is unaffected, since under `LEGACY_FRAMEWORK` the script references a locally-installed `Microsoft.Build.16.11.0` assembly directly (via a prior `nuget.exe install`) rather than going through `dotnet fsi`'s NuGet-audit-checked restore.

## Fix

Bump the referenced `Microsoft.Build` version from `16.11.0` to `17.3.0`, which pulls in `System.Drawing.Common` 6.0.0 instead (via `System.Configuration.ConfigurationManager 6.0.0`) — not affected by the advisory — eliminating the warning.

`17.3.0` is the **oldest** `Microsoft.Build` version that has the fix. As requested in nblockchain/conventions#351, I went back one version at a time from `17.8.43` (the initial candidate) and checked each one empirically (fresh NuGet cache, same `dotnet fsi` restore path that CI uses, NuGet audit included):

| `Microsoft.Build` version | pulls `System.Drawing.Common` | NuGet audit result on restore |
|---|---|---|
| 17.8.43 | 7.0.0 | ✅ clean |
| 17.8.29, 17.8.27, 17.8.3 | 7.0.0 | ❌ **NU1903 on `Microsoft.Build` itself**: [GHSA-w3q9-fxm7-j8fq](https://github.com/advisories/GHSA-w3q9-fxm7-j8fq) (CVE-2025-55247, high DoS; affects `>= 17.8.0, <= 17.8.29`, fixed in 17.8.43) |
| 17.7.2, 17.7.0, 17.6.3 | 7.0.0 | ✅ clean |
| 17.5.0, 17.4.0, 17.3.2, 17.3.1, **17.3.0** | 6.0.0 | ✅ clean |
| 17.2.2, 17.2.0, 17.1.0, 17.0.1, 17.0.0, 16.11.6, 16.11.0 | 4.7.0 | ❌ NU1904 on `System.Drawing.Common` 4.7.0: [GHSA-rxg9-xrhp-64gj](https://github.com/advisories/GHSA-rxg9-xrhp-64gj) (critical RCE; affects `< 4.7.2`, fixed in 4.7.2) — the original CI failure |

So the boundary is exactly at **17.3.0**: the first version whose `net6.0` dependency group moved `System.Configuration.ConfigurationManager` from `4.7.0` (→ `System.Drawing.Common 4.7.0`) to `6.0.0` (→ `System.Drawing.Common 6.0.0`). Note that `16.11.6` (a servicing release of the 16.11 line, released after 17.0.0) does **not** help: it still depends on `System.Configuration.ConfigurationManager 4.7.0`.

Since `wip/fixUpdateServers` is the stable branch, this PR uses the oldest fixed version, as requested; a newer version can be targeted on `master` later (e.g. `17.8.43`, which the conventions repo currently uses — but beware the 17.8.x pitfall: only `17.8.43` is clean in that line, `17.8.3`/`17.8.27`/`17.8.29` carry their own advisory).

## Verification

Reproduced and fixed locally from a clean repo state and clean NuGet cache, on both dotnet SDKs that CI lanes use for `dotnet fsi`: **10.0.400** (what the GitHub-hosted runners resolve to) and **8.0.424** (the vanilla `ubuntu:24.04` container lanes' `dotnet8`):

- Before (16.11.0): `make sanitycheck` prints the `NU1904` warning twice on stderr and fails with `Fsdk.Process+ProcessSucceededWithWarnings` at `make.fsx:529` (exit 2) — matching the CI failure exactly.
- After (17.3.0): `./configure.sh`, `make` and `make sanitycheck` all complete with exit code 0 and no warnings, and the sanity checks themselves pass for both solutions (`SolutionFile.Parse`, the only Microsoft.Build API used, works identically with 17.3.0).

Only `scripts/sanitycheck.fsx` needed changing; it's the only script referencing `Microsoft.Build` via `#r "nuget:"` (other `#r "nuget:"` references in the repo's `.fsx` scripts are for `Fsdk`, unaffected by these advisories).

---

**Note:** as requested in nblockchain/conventions#351, this PR targets the `wip/fixUpdateServers` branch, and its branch is rebased on top of `wip/fixUpdateServers` so the diff contains only the one-line fix. (CI runs from this fork need a maintainer's "Approve and run" click.)
