### PR TITLE
Backend/servers.json: added 1 more LTC server

### DIFF
--- a/src/GWallet.Backend/servers.json
+++ b/src/GWallet.Backend/servers.json
@@ -2818,6 +2818,21 @@
     "LTC": [
       {
         "ServerInfo": {
+          "NetworkPath": "electrum-ltc.ddns.net",
+          "ConnectionType": {
+            "Encrypted": false,
+            "Protocol": {
+              "Case": "Tcp",
+              "Fields": [
+                50001
+              ]
+            }
+          }
+        },
+        "CommunicationHistory": null
+      },
+      {
+        "ServerInfo": {
           "NetworkPath": "backup.electrum-ltc.org",
           "ConnectionType": {
             "Encrypted": false,


### PR DESCRIPTION
Found here:
https://github.com/spesmilo/electrumx/blob/280cb339aa158e099eb936033eecd15719770651/src/electrumx/lib/coins.py#L1006

Note: we don't add the others because all of them were already in our list, except one that is marked as p1000 (but not desirable because p1000 means that it has pruning enabled, with a depth of 1,000 transactions; more info here[1]).

[1] https://github.com/tarsgate/conventions/issues/356